### PR TITLE
Add simple type field auto mapping.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation "org.ow2.asm:asm-util:9.3"
     implementation "cuchaz:enigma:${enigma_version}"
     implementation "org.quiltmc:quilt-json5:1.0.1"
+    implementation "org.jetbrains:annotations:23.0.0"
 
     testImplementation "cuchaz:enigma-swing:${enigma_version}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'org.quiltmc.gradle.licenser' version '1.1.1'
 }
 
-version '1.1.0'
+version '1.2.0'
 group 'org.quiltmc'
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -26,6 +26,7 @@ dependencies {
     implementation "org.ow2.asm:asm-tree:9.3"
     implementation "org.ow2.asm:asm-util:9.3"
     implementation "cuchaz:enigma:${enigma_version}"
+    implementation "org.quiltmc:quilt-json5:1.0.1"
 
     testImplementation "cuchaz:enigma-swing:${enigma_version}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-enigma_version = 1.1.3
+enigma_version = 1.1.7

--- a/src/main/java/org/quiltmc/enigmaplugin/Arguments.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/Arguments.java
@@ -29,6 +29,7 @@ public class Arguments {
     public static final String DISABLE_LOGGER = "disable_logger";
     public static final String DISABLE_CODECS = "disable_codecs";
     public static final String CUSTOM_CODECS = "custom_codecs";
+    public static final String SIMPLE_TYPE_FIELD_NAMES_PATH = "simple_type_field_names_path";
 
     public static <T extends EnigmaService> boolean isDisabled(EnigmaServiceContext<T> context, String arg) {
         return context.getArgument(arg).map(Boolean::parseBoolean).orElse(false);

--- a/src/main/java/org/quiltmc/enigmaplugin/index/Index.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/Index.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.enigmaplugin.index;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+
+public interface Index extends Opcodes {
+    void visitClassNode(ClassNode classNode);
+}

--- a/src/main/java/org/quiltmc/enigmaplugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/JarIndexer.java
@@ -50,7 +50,8 @@ public class JarIndexer implements JarIndexerService, Opcodes {
                 .orElse(List.of());
         this.codecIndex.addCustomCodecs(codecs);
 
-        this.simpleTypeSingleIndex.loadRegistry(context.getArgument(Arguments.SIMPLE_TYPE_FIELD_NAMES_PATH).orElse(null));
+        this.simpleTypeSingleIndex.loadRegistry(context.getArgument(Arguments.SIMPLE_TYPE_FIELD_NAMES_PATH)
+                .map(context::getPath).orElse(null));
         return this;
     }
 

--- a/src/main/java/org/quiltmc/enigmaplugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/JarIndexer.java
@@ -24,6 +24,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 import org.quiltmc.enigmaplugin.Arguments;
 import org.quiltmc.enigmaplugin.index.enumfields.EnumFieldsIndex;
+import org.quiltmc.enigmaplugin.index.simple_type_single.SimpleTypeSingleIndex;
 
 import java.util.List;
 import java.util.Set;
@@ -33,6 +34,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
     private final EnumFieldsIndex enumFieldsIndex = new EnumFieldsIndex();
     private final CodecIndex codecIndex = new CodecIndex();
     private final LoggerIndex loggerIndex = new LoggerIndex();
+    private final SimpleTypeSingleIndex simpleTypeSingleIndex = new SimpleTypeSingleIndex();
     private boolean disableRecordIndexing = false;
     private boolean disableEnumFieldsIndexing = false;
     private boolean disableCodecsIndexing = false;
@@ -47,6 +49,8 @@ public class JarIndexer implements JarIndexerService, Opcodes {
         List<String> codecs = context.getArgument(Arguments.CUSTOM_CODECS).map(s -> List.of(s.split(",[\n ]*")))
                 .orElse(List.of());
         this.codecIndex.addCustomCodecs(codecs);
+
+        this.simpleTypeSingleIndex.loadRegistry(context.getArgument(Arguments.SIMPLE_TYPE_FIELD_NAMES_PATH).orElse(null));
         return this;
     }
 
@@ -55,13 +59,16 @@ public class JarIndexer implements JarIndexerService, Opcodes {
         for (String className : scope) {
             ClassNode node = classProvider.get(className);
             if (node != null) {
-                visitClassNode(node);
+                this.visitClassNode(node);
+                this.simpleTypeSingleIndex.visitClassNode(classProvider, node);
             }
         }
 
         if (!disableEnumFieldsIndexing) {
             enumFieldsIndex.findFieldNames();
         }
+
+        this.simpleTypeSingleIndex.dropCache();
     }
 
     private void visitClassNode(ClassNode node) {
@@ -96,5 +103,9 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 
     public LoggerIndex getLoggerIndex() {
         return this.loggerIndex;
+    }
+
+    public SimpleTypeSingleIndex getSimpleTypeSingleIndex() {
+        return this.simpleTypeSingleIndex;
     }
 }

--- a/src/main/java/org/quiltmc/enigmaplugin/index/LoggerIndex.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/LoggerIndex.java
@@ -19,18 +19,18 @@ package org.quiltmc.enigmaplugin.index;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.FieldEntry;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 import org.quiltmc.enigmaplugin.util.AsmUtil;
 
 import java.util.HashSet;
 import java.util.Set;
 
-public class LoggerIndex implements Opcodes {
+public class LoggerIndex implements Index {
     private static final String LOGGER_TYPE = "Lorg/slf4j/Logger;";
 
     private final Set<FieldEntry> fields = new HashSet<>();
 
+    @Override
     public void visitClassNode(ClassNode parent) {
         var parentEntry = new ClassEntry(parent.name);
 

--- a/src/main/java/org/quiltmc/enigmaplugin/index/RecordIndex.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/RecordIndex.java
@@ -38,7 +38,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class RecordIndex implements Opcodes {
+public class RecordIndex implements Index {
     private static final Handle TO_STRING_HANDLE = new Handle(H_INVOKESTATIC, "java/lang/runtime/ObjectMethods", "bootstrap", "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;", false);
     private static final Handle HASH_CODE_HANDLE = new Handle(H_INVOKESTATIC, "java/lang/runtime/ObjectMethods", "bootstrap", "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;", false);
     private static final Handle EQUALS_HANDLE = new Handle(H_INVOKESTATIC, "java/lang/runtime/ObjectMethods", "bootstrap", "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;", false);
@@ -172,6 +172,7 @@ public class RecordIndex implements Opcodes {
         return null;
     }
 
+    @Override
     public void visitClassNode(ClassNode node) {
         ClassEntry classEntry = getClassEntry(node);
         if (records.containsKey(classEntry) && records.get(classEntry).hasComponents()) {

--- a/src/main/java/org/quiltmc/enigmaplugin/index/enumfields/EnumFieldsIndex.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/enumfields/EnumFieldsIndex.java
@@ -21,6 +21,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.quiltmc.enigmaplugin.index.Index;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,11 +30,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class EnumFieldsIndex implements Opcodes {
+public class EnumFieldsIndex implements Index {
     private final Map<String, Set<String>> enumFields = new HashMap<>();
     private final Map<String, List<MethodNode>> enumStaticInitializers = new HashMap<>();
     private Map<FieldEntry, String> fieldNames;
 
+    @Override
     public void visitClassNode(ClassNode node) {
         for (FieldNode field : node.fields) {
             if ((field.access & ACC_ENUM) != 0) {

--- a/src/main/java/org/quiltmc/enigmaplugin/index/simple_type_single/SimpleTypeFieldNamesRegistry.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/simple_type_single/SimpleTypeFieldNamesRegistry.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.enigmaplugin.index.simple_type_single;
+
+import org.jetbrains.annotations.Nullable;
+import org.quiltmc.enigmaplugin.util.CasingUtil;
+import org.quiltmc.json5.JsonReader;
+import org.quiltmc.json5.JsonToken;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.Predicate;
+
+public class SimpleTypeFieldNamesRegistry {
+    private final Path path;
+    /**
+     * Using a {@link LinkedHashMap} to ensure we keep the read order.
+     */
+    private final Map<String, Entry> entries = new LinkedHashMap<>();
+
+    public SimpleTypeFieldNamesRegistry(Path path) {
+        this.path = path;
+    }
+
+    public @Nullable Entry getEntry(String type) {
+        return this.entries.get(type);
+    }
+
+    public void read() {
+        try (var reader = JsonReader.json5(this.path)) {
+            if (reader.peek() != JsonToken.BEGIN_OBJECT) {
+                return;
+            }
+
+            reader.beginObject();
+
+            while (reader.hasNext()) {
+                String type = reader.nextName();
+
+                switch (reader.peek()) {
+                    case STRING -> {
+                        String localName = reader.nextString();
+                        this.entries.put(type, new Entry(type, localName, CasingUtil.toScreamingSnakeCase(localName)));
+                    }
+                    case BEGIN_OBJECT -> {
+                        String localName = null;
+                        String staticName = null;
+                        boolean exclusive = false;
+                        List<Name> fallback = Collections.emptyList();
+
+                        reader.beginObject();
+
+                        while (reader.hasNext()) {
+                            String key = reader.nextName();
+
+                            switch (key) {
+                                case "local_name" -> localName = reader.nextString();
+                                case "static_name" -> staticName = reader.nextString();
+                                case "exclusive" -> exclusive = reader.nextBoolean();
+                                case "fallback" -> {
+                                    reader.beginArray();
+
+                                    fallback = this.collectFallbacks(reader, type);
+
+                                    reader.endArray();
+                                }
+                                default -> reader.skipValue();
+                            }
+                        }
+
+                        reader.endObject();
+
+                        if (localName == null) {
+                            System.err.println("Failed parsing local name for type " + type);
+                            break;
+                        }
+
+                        if (staticName == null) staticName = CasingUtil.toScreamingSnakeCase(localName);
+
+                        this.entries.put(type, new Entry(type, new Name(localName, staticName), exclusive, fallback));
+                    }
+                    default -> reader.skipValue();
+                }
+            }
+
+            reader.endObject();
+        } catch (IOException e) {
+            System.err.println("Failed to read simple type field names registry.");
+            e.printStackTrace();
+        }
+    }
+
+    private List<Name> collectFallbacks(JsonReader reader, String type) throws IOException {
+        var list = new ArrayList<Name>();
+
+        while (reader.hasNext()) {
+            switch (reader.peek()) {
+                case STRING -> {
+                    String name = reader.nextString();
+                    list.add(new Name(name, CasingUtil.toScreamingSnakeCase(name)));
+                }
+                case BEGIN_OBJECT -> {
+                    String localName = null;
+                    String staticName = null;
+                    reader.beginObject();
+
+                    while (reader.hasNext()) {
+                        String key = reader.nextName();
+
+                        switch (key) {
+                            case "local_name" -> localName = reader.nextString();
+                            case "static_name" -> staticName = reader.nextString();
+                            default -> reader.skipValue();
+                        }
+                    }
+
+                    reader.endObject();
+
+                    if (localName == null) {
+                        System.err.println("Failed parsing fallback local name for type " + type);
+                        break;
+                    }
+
+                    if (staticName == null) staticName = CasingUtil.toScreamingSnakeCase(localName);
+
+                    list.add(new Name(localName, staticName));
+                }
+            }
+        }
+
+        return list;
+    }
+
+    public record Entry(String type, Name name, boolean exclusive, List<Name> fallback) {
+        public Entry(String type, String localName, String staticName) {
+            this(type, new Name(localName, staticName), false, Collections.emptyList());
+        }
+
+        public @Nullable Name findFallback(Predicate<Name> predicate) {
+            for (var fallback : this.fallback) {
+                if (predicate.test(fallback))
+                    return fallback;
+            }
+
+            return null;
+        }
+    }
+
+    public record Name(String local, String staticName) {
+    }
+}

--- a/src/main/java/org/quiltmc/enigmaplugin/index/simple_type_single/SimpleTypeSingleIndex.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/simple_type_single/SimpleTypeSingleIndex.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.enigmaplugin.index.simple_type_single;
+
+import cuchaz.enigma.classprovider.ClassProvider;
+import cuchaz.enigma.translation.representation.MethodDescriptor;
+import cuchaz.enigma.translation.representation.TypeDescriptor;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.ParameterNode;
+import org.quiltmc.enigmaplugin.index.simple_type_single.SimpleTypeFieldNamesRegistry.Name;
+import org.quiltmc.enigmaplugin.util.AsmUtil;
+
+import java.nio.file.Paths;
+import java.util.*;
+
+/**
+ * Index of fields/local variables that are of a rather simple type (as-in easy to guess the variable name) and which
+ * they are entirely unique within their context (no other fields/local vars in the same scope have the same type).
+ */
+public class SimpleTypeSingleIndex implements Opcodes {
+    private final Map<ParameterEntry, String> parameters = new HashMap<>();
+    private final Map<FieldEntry, String> fields = new HashMap<>();
+    private final Map<ClassNode, Map<String, FieldBuildingEntry>> fieldCache = new HashMap<>();
+    private SimpleTypeFieldNamesRegistry registry;
+
+    public void loadRegistry(String path) {
+        if (path == null) {
+            this.registry = null;
+            return;
+        }
+
+        this.registry = new SimpleTypeFieldNamesRegistry(Paths.get(path));
+        this.registry.read();
+    }
+
+    public boolean isEnabled() {
+        return this.registry != null;
+    }
+
+    public void dropCache() {
+        this.fieldCache.clear();
+    }
+
+    public @Nullable String getField(FieldEntry fieldEntry) {
+        return this.fields.get(fieldEntry);
+    }
+
+    public @Nullable String getParam(ParameterEntry paramEntry) {
+        return this.parameters.get(paramEntry);
+    }
+
+    public List<ParameterEntry> getParamsOf(MethodEntry methodEntry) {
+        var params = new ArrayList<ParameterEntry>();
+
+        this.parameters.forEach((param, name) -> {
+            if (param.parent.equals(methodEntry)) {
+                params.add(param);
+            }
+        });
+
+        return params;
+    }
+
+    public void visitClassNode(ClassProvider provider, ClassNode classNode) {
+        if (!this.isEnabled()) return;
+
+        var parentEntry = new ClassEntry(classNode.name);
+
+        this.collectMatchingFields(provider, classNode).forEach((name, entry) -> {
+            if (entry != FieldBuildingEntry.NULL) {
+                var fieldEntry = new FieldEntry(parentEntry, entry.node().name, new TypeDescriptor(entry.node().desc));
+                this.fields.put(fieldEntry,
+                        AsmUtil.matchAccess(entry.node(), ACC_STATIC, ACC_FINAL)
+                                ? entry.name().staticName()
+                                : entry.name().local()
+                );
+            }
+        });
+
+        for (var method : classNode.methods) {
+            if (method.parameters == null) continue;
+
+            var methodDescriptor = new MethodDescriptor(method.desc);
+            var methodEntry = new MethodEntry(parentEntry, method.name, methodDescriptor);
+            var argTypes = Type.getArgumentTypes(method.desc);
+
+            var types = new HashMap<Type, Integer>();
+
+            for (var type : argTypes) {
+                types.compute(type, (t, old) -> {
+                    if (old == null) return 0;
+                    else return old + 1;
+                });
+            }
+
+            var bannedTypes = new HashSet<Type>();
+            types.forEach((type, amount) -> {
+                if (amount > 1) bannedTypes.add(type);
+            });
+
+            this.collectMatchingParameters(method, bannedTypes, argTypes).forEach((name, param) -> {
+                if (!param.isNull()) {
+                    boolean isStatic = AsmUtil.maskMatch(method.access, ACC_STATIC);
+                    var paramEntry = new ParameterEntry(methodEntry, param.index() + (isStatic ? 0 : 1));
+                    this.parameters.put(paramEntry, name);
+                }
+            });
+        }
+    }
+
+    private Map<String, FieldBuildingEntry> collectMatchingFields(ClassProvider classProvider,
+                                                                  ClassNode classNode) {
+        var existing = this.fieldCache.get(classNode);
+
+        if (existing != null) return existing;
+
+        var knownFields = new HashMap<String, FieldBuildingEntry>();
+        for (var field : classNode.fields) {
+            if (classNode.outerClass != null) {
+                ClassNode outerClass = classProvider.get(classNode.outerClass);
+
+                if (outerClass != null) {
+                    knownFields.putAll(this.collectMatchingFields(classProvider, outerClass));
+                }
+            }
+
+            if (field.desc.charAt(0) != 'L') continue;
+            String type = field.desc.substring(1, field.desc.length() - 1);
+
+            var entry = this.registry.getEntry(type);
+            if (entry != null) {
+                var existingEntry = knownFields.get(entry.name().local());
+
+                if (existingEntry != null) {
+                    Name foundFallback = entry.findFallback(fallback -> !knownFields.containsKey(fallback.local()));
+
+                    if (foundFallback != null) {
+                        knownFields.put(foundFallback.local(), new FieldBuildingEntry(field, foundFallback, entry));
+
+                        if (existingEntry != FieldBuildingEntry.NULL && existingEntry.entry().exclusive()) {
+                            Name replacement = existingEntry.entry().findFallback(
+                                    fallback -> !knownFields.containsKey(fallback.local())
+                            );
+
+                            knownFields.put(entry.name().local(), FieldBuildingEntry.NULL);
+
+                            if (replacement != null) {
+                                knownFields.put(replacement.local(),
+                                        new FieldBuildingEntry(existingEntry.node(), replacement, existingEntry.entry())
+                                );
+                            }
+                        }
+                    } else {
+                        knownFields.put(entry.name().local(), FieldBuildingEntry.NULL);
+                    }
+                } else {
+                    knownFields.put(entry.name().local(), new FieldBuildingEntry(field, entry.name(), entry));
+                }
+            }
+        }
+
+        this.fieldCache.put(classNode, knownFields);
+
+        return knownFields;
+    }
+
+    private Map<String, ParameterBuildingEntry> collectMatchingParameters(MethodNode method, Set<Type> bannedTypes,
+                                                                          Type[] argTypes) {
+        var knownParameters = new HashMap<String, ParameterBuildingEntry>();
+
+        for (int index = 0; index < method.parameters.size(); index++) {
+            if (bannedTypes.contains(argTypes[index])) continue;
+
+            ParameterNode node = method.parameters.get(index);
+            String desc = argTypes[index].getDescriptor();
+            if (desc.charAt(0) != 'L') continue;
+            String type = desc.substring(1, desc.length() - 1);
+
+            var entry = this.registry.getEntry(type);
+            if (entry != null) {
+                ParameterBuildingEntry existingEntry = knownParameters.get(entry.name().local());
+
+                if (existingEntry != null) {
+                    if (existingEntry.entry() == entry) {
+                        knownParameters.put(entry.name().local(), ParameterBuildingEntry.createNull(entry));
+                        continue;
+                    }
+
+                    Name foundFallback = entry.findFallback(fallback -> !knownParameters.containsKey(fallback.local()));
+
+                    if (foundFallback != null) {
+                        knownParameters.put(foundFallback.local(), new ParameterBuildingEntry(node, index, entry));
+
+                        if (!existingEntry.isNull() && existingEntry.entry().exclusive()) {
+                            Name replacement = existingEntry.entry().findFallback(
+                                    fallback -> !knownParameters.containsKey(fallback.local())
+                            );
+
+                            knownParameters.put(entry.name().local(), ParameterBuildingEntry.createNull(entry));
+
+                            if (replacement != null) {
+                                knownParameters.put(replacement.local(), new ParameterBuildingEntry(
+                                        existingEntry.node(), existingEntry.index(), existingEntry.entry()
+                                ));
+                            }
+                        }
+                    } else {
+                        knownParameters.put(entry.name().local(), ParameterBuildingEntry.createNull(entry));
+                    }
+                } else {
+                    knownParameters.put(entry.name().local(), new ParameterBuildingEntry(node, index, entry));
+                }
+            }
+        }
+
+        return knownParameters;
+    }
+
+    private record FieldBuildingEntry(FieldNode node, Name name, SimpleTypeFieldNamesRegistry.Entry entry) {
+        public static final FieldBuildingEntry NULL = new FieldBuildingEntry(null, null, null);
+    }
+
+    private record ParameterBuildingEntry(ParameterNode node, int index, SimpleTypeFieldNamesRegistry.Entry entry) {
+        public static ParameterBuildingEntry createNull(SimpleTypeFieldNamesRegistry.Entry entry) {
+            return new ParameterBuildingEntry(null, -1, entry);
+        }
+
+        public boolean isNull() {
+            return this.node == null;
+        }
+    }
+
+    public record ParameterEntry(MethodEntry parent, int index) {
+        public static ParameterEntry fromLocalVariableEntry(LocalVariableEntry entry) {
+            return new ParameterEntry(entry.getParent(), entry.getIndex());
+        }
+    }
+}

--- a/src/main/java/org/quiltmc/enigmaplugin/index/simple_type_single/SimpleTypeSingleIndex.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/simple_type_single/SimpleTypeSingleIndex.java
@@ -24,6 +24,7 @@ import cuchaz.enigma.translation.representation.entry.FieldEntry;
 import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
@@ -72,6 +73,7 @@ public class SimpleTypeSingleIndex implements Opcodes {
         return this.parameters.get(paramEntry);
     }
 
+    @TestOnly
     public List<ParameterEntry> getParamsOf(MethodEntry methodEntry) {
         var params = new ArrayList<ParameterEntry>();
 

--- a/src/main/java/org/quiltmc/enigmaplugin/index/simple_type_single/SimpleTypeSingleIndex.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/index/simple_type_single/SimpleTypeSingleIndex.java
@@ -34,7 +34,7 @@ import org.objectweb.asm.tree.ParameterNode;
 import org.quiltmc.enigmaplugin.index.simple_type_single.SimpleTypeFieldNamesRegistry.Name;
 import org.quiltmc.enigmaplugin.util.AsmUtil;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -47,13 +47,13 @@ public class SimpleTypeSingleIndex implements Opcodes {
     private final Map<ClassNode, Map<String, FieldBuildingEntry>> fieldCache = new HashMap<>();
     private SimpleTypeFieldNamesRegistry registry;
 
-    public void loadRegistry(String path) {
+    public void loadRegistry(Path path) {
         if (path == null) {
             this.registry = null;
             return;
         }
 
-        this.registry = new SimpleTypeFieldNamesRegistry(Paths.get(path));
+        this.registry = new SimpleTypeFieldNamesRegistry(path);
         this.registry.read();
     }
 

--- a/src/main/java/org/quiltmc/enigmaplugin/proposal/NameProposerService.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/proposal/NameProposerService.java
@@ -37,6 +37,10 @@ public class NameProposerService implements NameProposalService {
         this.addIfEnabled(context, Arguments.DISABLE_EQUALS, EqualsNameProposer::new);
         this.addIfEnabled(context, Arguments.DISABLE_LOGGER, () -> new LoggerNameProposer(indexer.getLoggerIndex()));
         this.addIfEnabled(context, Arguments.DISABLE_CODECS, () -> new CodecNameProposer(indexer.getCodecIndex()));
+
+        if (indexer.getSimpleTypeSingleIndex().isEnabled()) {
+            this.nameProposers.add(new SimpleTypeFieldNameProposer(indexer.getSimpleTypeSingleIndex()));
+        }
     }
 
     private void addIfEnabled(EnigmaServiceContext<NameProposalService> context, String name, Supplier<NameProposer<?>> factory) {

--- a/src/main/java/org/quiltmc/enigmaplugin/proposal/SimpleTypeFieldNameProposer.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/proposal/SimpleTypeFieldNameProposer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.enigmaplugin.proposal;
+
+import cuchaz.enigma.translation.mapping.EntryRemapper;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
+import org.quiltmc.enigmaplugin.index.simple_type_single.SimpleTypeSingleIndex;
+import org.quiltmc.enigmaplugin.index.simple_type_single.SimpleTypeSingleIndex.ParameterEntry;
+
+import java.util.Optional;
+
+public class SimpleTypeFieldNameProposer implements NameProposer<Entry<?>> {
+    private final SimpleTypeSingleIndex index;
+
+    public SimpleTypeFieldNameProposer(SimpleTypeSingleIndex index) {
+        this.index = index;
+    }
+
+    @Override
+    public Optional<String> doProposeName(Entry<?> entry, EntryRemapper remapper) {
+        if (entry instanceof FieldEntry fieldEntry) {
+            return Optional.ofNullable(this.index.getField(fieldEntry));
+        } else if (entry instanceof LocalVariableEntry localVariableEntry) {
+            var paramEntry = ParameterEntry.fromLocalVariableEntry(localVariableEntry);
+            return Optional.ofNullable(this.index.getParam(paramEntry));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean canPropose(Entry<?> entry) {
+        return entry instanceof FieldEntry || entry instanceof LocalVariableEntry;
+    }
+
+    @Override
+    public Entry<?> upcast(Entry<?> entry) {
+        return entry;
+    }
+}

--- a/src/main/java/org/quiltmc/enigmaplugin/util/CasingUtil.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/util/CasingUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.enigmaplugin.util;
+
+public class CasingUtil {
+    public static String toCamelCase(String name) {
+        // Make sure the first letter is lower case
+        name = Character.toLowerCase(name.charAt(0)) + name.substring(1);
+        while (name.contains("_")) {
+            name = name.replaceFirst("_[a-z]", String.valueOf(Character.toUpperCase(name.charAt(name.indexOf('_') + 1))));
+        }
+        return name;
+    }
+
+    public static String toScreamingSnakeCase(String name) {
+        var builder = new StringBuilder();
+
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+
+            if (c == '_') {
+                builder.append(c);
+            } else {
+                if (Character.isUpperCase(c) && i != 0) {
+                    builder.append('_');
+                }
+
+                builder.append(Character.toUpperCase(c));
+            }
+        }
+
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
The names are read from a JSON5 file.

Here's a sample of the JSON5 file I used for testing, which we might want to see integrated in QM later on.

```json5
{
  // Codec
  "com/mojang/serialization/Codec": "codec",
  // DFU
  "com/mojang/datafixers/schemas/Schema": "schema",
  // Brigadier
  "com/mojang/brigadier/StringReader": "reader",

  // Registries
  "net/minecraft/unmapped/C_tqxyjqsk": "registry",
  "net/minecraft/unmapped/C_xhhleach": "registryKey",

  // Client
  "net/minecraft/unmapped/C_ayfeobid": "client", // MinecraftClient
  "net/minecraft/unmapped/C_cnszsxvd": "matrices", // MatrixStack
  "net/minecraft/unmapped/C_igrgeffe": "vertexConsumers", // VertexConsumerProvider
  "net/minecraft/unmapped/C_mavozmpp": "textRenderer",

  // Pos
  "net/minecraft/unmapped/C_hynzadkk": "pos", // BlockPos
  "net/minecraft/unmapped/C_hynzadkk$C_egqitdjk": {
    local_name: "pos",
    "fallback": [
      "mutablePos"
    ]
  },
  "net/minecraft/unmapped/C_ovcqqyqp": "globalPos", // GlobalPos

  // Common
  "net/minecraft/unmapped/C_rlomrsco": "random", // RandomGenerator
  "net/minecraft/unmapped/C_xpuuihxf": "direction",
  "net/minecraft/unmapped/C_eslcbfsq": "profiler",

  // States
  "net/minecraft/unmapped/C_txtbiemp": { // BlockState
    local_name: "state",
    exclusive: true,
    fallback: [
      "blockState"
    ]
  },
  "net/minecraft/unmapped/C_xqketiuf": { // FluidState
    local_name: "state",
    exclusive: true,
    fallback: [
      "fluidState"
    ]
  },

  // Block
  "net/minecraft/unmapped/C_mmxmpdoq": "block",

  // Item
  "net/minecraft/unmapped/C_sddaxwyk": "stack", // ItemStack

  // Entity
  "net/minecraft/unmapped/C_rjqjaxef": "brain",
  "net/minecraft/unmapped/C_uzzvxofv": {
    local_name: "reason",
    fallback: [
      "spawnReason"
    ]
  },

  // Resources
  "net/minecraft/unmapped/C_tmnrpasf": "resourceManager",
  "net/minecraft/unmapped/C_carvbxzj": { // AutoCloseableResourceManager
    local_name: "resourceManager",
    fallback: [
      "autoCloseableResourceManager"
    ]
  },
  "net/minecraft/unmapped/C_migzkpst": "resources", // ServerReloadableResources

  // World
  "net/minecraft/unmapped/C_cdctfzbn": "world",
  "net/minecraft/unmapped/C_agsukcmb": { // TestableWorld
    local_name: "world",
    fallback: [
      "testableWorld"
    ]
  },
  "net/minecraft/unmapped/C_bdwnwhiu": { // ServerWorld
    local_name: "world",
    exclusive: true,
    fallback: [
      "serverWorld"
    ]
  },
  "net/minecraft/unmapped/C_ghdnlrrw": { // ClientWorld
    local_name: "world",
    exclusive: true,
    fallback: [
      "clientWorld"
    ]
  }
}
```