### PR TITLE
add a name proposer that provides the unmapped name if it doesn't match hashed convention

### DIFF
--- a/src/main/java/org/quiltmc/enigmaplugin/Arguments.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/Arguments.java
@@ -31,6 +31,7 @@ public class Arguments {
 	public static final String DISABLE_GETTER_SETTER = "disable_getter_setter";
 	public static final String DISABLE_CODECS = "disable_codecs";
 	public static final String CUSTOM_CODECS = "custom_codecs";
+	public static final String MAP_NON_HASHED = "map_non_hashed";
 	public static final String SIMPLE_TYPE_FIELD_NAMES_PATH = "simple_type_field_names_path";
 
 	public static <T extends EnigmaService> boolean isDisabled(EnigmaServiceContext<T> context, String arg) {

--- a/src/main/java/org/quiltmc/enigmaplugin/proposal/MojangNameProposer.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/proposal/MojangNameProposer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.enigmaplugin.proposal;
 
 import cuchaz.enigma.translation.mapping.EntryRemapper;

--- a/src/main/java/org/quiltmc/enigmaplugin/proposal/MojangNameProposer.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/proposal/MojangNameProposer.java
@@ -1,0 +1,43 @@
+package org.quiltmc.enigmaplugin.proposal;
+
+import cuchaz.enigma.translation.mapping.EntryRemapper;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import org.quiltmc.enigmaplugin.index.JarIndexer;
+
+import java.util.Optional;
+
+/**
+ * If the entry is not deobfuscated, propose the name that's already provided.
+ * This is useful to avoid situations where we simply click "mark as deobf" to name something.
+ */
+public class MojangNameProposer implements NameProposer<Entry<?>> {
+    @SuppressWarnings("unused")
+    public MojangNameProposer(JarIndexer indexer) {
+    }
+
+    @Override
+    public Optional<String> doProposeName(Entry<?> entry, EntryRemapper remapper) {
+        String name = entry.getName();
+        if (remapper.getDeobfMapping(entry).targetName() == null
+                && (entry instanceof FieldEntry && !name.startsWith("f_")
+                || entry instanceof MethodEntry && !name.startsWith("m_")
+                || entry instanceof ClassEntry && !name.startsWith("C_"))) {
+            return Optional.of(name);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean canPropose(Entry<?> entry) {
+        return entry instanceof FieldEntry || entry instanceof MethodEntry || entry instanceof ClassEntry;
+    }
+
+    @Override
+    public Entry<?> upcast(Entry<?> entry) {
+        return entry;
+    }
+}

--- a/src/main/java/org/quiltmc/enigmaplugin/proposal/MojangNameProposer.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/proposal/MojangNameProposer.java
@@ -19,7 +19,7 @@ public class MojangNameProposer implements NameProposer<Entry<?>> {
     }
 
     @Override
-    public Optional<String> doProposeName(Entry<?> entry, EntryRemapper remapper) {
+    public Optional<String> doProposeName(Entry<?> entry, NameProposerService service, EntryRemapper remapper) {
         String name = entry.getName();
         if (remapper.getDeobfMapping(entry).targetName() == null
                 && (entry instanceof FieldEntry && !name.startsWith("f_")

--- a/src/main/java/org/quiltmc/enigmaplugin/proposal/NameProposerService.java
+++ b/src/main/java/org/quiltmc/enigmaplugin/proposal/NameProposerService.java
@@ -41,6 +41,7 @@ public class NameProposerService implements NameProposalService {
 		this.addIfEnabled(context, Arguments.DISABLE_EQUALS, EqualsNameProposer::new);
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_LOGGER, LoggerNameProposer::new);
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_CODECS, CodecNameProposer::new);
+		this.addIfEnabled(context, indexer, Arguments.MAP_NON_HASHED, MojangNameProposer::new);
 
 		if (indexer.getSimpleTypeSingleIndex().isEnabled()) {
 			this.nameProposers.add(new SimpleTypeFieldNameProposer(indexer));


### PR DESCRIPTION
pretty simple thing that prevents us clicking "mark as deobf" all the time while mapping