### PR TITLE
Cleanup the constant fields name finder (renamed from enum fields)

### DIFF
--- a/src/main/java/org/quiltmc/enigma_plugin/Arguments.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/Arguments.java
@@ -24,7 +24,7 @@ import org.quiltmc.enigma.api.service.EnigmaServiceContext;
  */
 public class Arguments {
 	public static final String DISABLE_RECORDS = "disable_records";
-	public static final String DISABLE_ENUM_FIELDS = "disable_enum_fields";
+	public static final String DISABLE_CONSTANT_FIELDS = "disable_constant_fields";
 	public static final String DISABLE_EQUALS = "disable_equals";
 	public static final String DISABLE_LOGGER = "disable_logger";
 	public static final String DISABLE_CONSTRUCTOR_PARAMS = "disable_constructor_params";

--- a/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
@@ -39,7 +39,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 	private final ConstructorParametersIndex constructorParametersIndex = new ConstructorParametersIndex();
 	private final GetterSetterIndex getterSetterIndex = new GetterSetterIndex();
 	private boolean disableRecordIndexing = false;
-	private boolean disableEnumFieldsIndexing = false;
+	private boolean disableConstantFieldIndexing = false;
 	private boolean disableCodecsIndexing = false;
 	private boolean disableLoggerIndexing = false;
 	private boolean disableConstructorParametersIndexing = false;
@@ -47,7 +47,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 
 	public JarIndexer withContext(EnigmaServiceContext<JarIndexerService> context) {
 		this.disableRecordIndexing = Arguments.isDisabled(context, Arguments.DISABLE_RECORDS);
-		this.disableEnumFieldsIndexing = Arguments.isDisabled(context, Arguments.DISABLE_ENUM_FIELDS);
+		this.disableConstantFieldIndexing = Arguments.isDisabled(context, Arguments.DISABLE_CONSTANT_FIELDS);
 		this.disableCodecsIndexing = Arguments.isDisabled(context, Arguments.DISABLE_CODECS);
 		this.disableLoggerIndexing = Arguments.isDisabled(context, Arguments.DISABLE_LOGGER);
 		this.disableConstructorParametersIndexing = Arguments.isDisabled(context, Arguments.DISABLE_CONSTRUCTOR_PARAMS);
@@ -72,7 +72,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 			}
 		}
 
-		if (!this.disableEnumFieldsIndexing) {
+		if (!this.disableConstantFieldIndexing) {
 			this.constantFieldIndex.findFieldNames();
 		}
 
@@ -88,7 +88,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 			}
 		}
 
-		if (!this.disableEnumFieldsIndexing) {
+		if (!this.disableConstantFieldIndexing) {
 			this.constantFieldIndex.visitClassNode(node);
 		}
 
@@ -113,7 +113,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 		return this.recordIndex;
 	}
 
-	public ConstantFieldIndex getEnumFieldsIndex() {
+	public ConstantFieldIndex getConstantFieldIndex() {
 		return this.constantFieldIndex;
 	}
 

--- a/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
@@ -24,7 +24,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 import org.quiltmc.enigma_plugin.Arguments;
 import org.quiltmc.enigma_plugin.QuiltEnigmaPlugin;
-import org.quiltmc.enigma_plugin.index.enum_fields.EnumFieldsIndex;
+import org.quiltmc.enigma_plugin.index.constant_fields.ConstantFieldIndex;
 import org.quiltmc.enigma_plugin.index.simple_type_single.SimpleTypeSingleIndex;
 
 import java.util.List;
@@ -32,7 +32,7 @@ import java.util.Set;
 
 public class JarIndexer implements JarIndexerService, Opcodes {
 	private final RecordIndex recordIndex = new RecordIndex();
-	private final EnumFieldsIndex enumFieldsIndex = new EnumFieldsIndex();
+	private final ConstantFieldIndex constantFieldIndex = new ConstantFieldIndex();
 	private final CodecIndex codecIndex = new CodecIndex();
 	private final LoggerIndex loggerIndex = new LoggerIndex();
 	private final SimpleTypeSingleIndex simpleTypeSingleIndex = new SimpleTypeSingleIndex();
@@ -73,7 +73,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 		}
 
 		if (!this.disableEnumFieldsIndexing) {
-			this.enumFieldsIndex.findFieldNames();
+			this.constantFieldIndex.findFieldNames();
 		}
 
 		this.simpleTypeSingleIndex.dropCache();
@@ -89,7 +89,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 		}
 
 		if (!this.disableEnumFieldsIndexing) {
-			this.enumFieldsIndex.visitClassNode(node);
+			this.constantFieldIndex.visitClassNode(node);
 		}
 
 		if (!this.disableCodecsIndexing) {
@@ -113,8 +113,8 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 		return this.recordIndex;
 	}
 
-	public EnumFieldsIndex getEnumFieldsIndex() {
-		return this.enumFieldsIndex;
+	public ConstantFieldIndex getEnumFieldsIndex() {
+		return this.constantFieldIndex;
 	}
 
 	public CodecIndex getCodecIndex() {

--- a/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
@@ -64,6 +64,8 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 
 	@Override
 	public void acceptJar(Set<String> scope, ClassProvider classProvider, JarIndex jarIndex) {
+		this.constantFieldIndex.clear();
+
 		for (String className : scope) {
 			ClassNode node = classProvider.get(className);
 			if (node != null) {

--- a/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldIndex.java
@@ -59,6 +59,12 @@ public class ConstantFieldIndex implements Index {
 		}
 	}
 
+	public void clear() {
+		this.enumFields.clear();
+		this.staticInitializers.clear();
+		this.fieldNames = null;
+	}
+
 	public boolean hasName(FieldEntry field) {
 		return this.fieldNames.containsKey(field);
 	}

--- a/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldIndex.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.quiltmc.enigma_plugin.index.enum_fields;
+package org.quiltmc.enigma_plugin.index.constant_fields;
 
 import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
 import org.objectweb.asm.tree.ClassNode;
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class EnumFieldsIndex implements Index {
+public class ConstantFieldIndex implements Index {
 	private final Map<String, Set<String>> enumFields = new HashMap<>();
 	private final Map<String, List<MethodNode>> staticInitializers = new HashMap<>();
 	private Map<FieldEntry, String> fieldNames;
@@ -39,7 +39,7 @@ public class EnumFieldsIndex implements Index {
 		for (FieldNode field : node.fields) {
 			if ((field.access & ACC_ENUM) != 0) {
 				if (!this.enumFields.computeIfAbsent(node.name, k -> new HashSet<>()).add(field.name + ":" + field.desc)) {
-					throw new IllegalStateException("Found a duplicate enum field with name \"" + field.name + "\"");
+					throw new IllegalStateException("Found a duplicate enum field with name \"" + field.name + "\" in class " + node.name);
 				}
 			}
 		}
@@ -53,7 +53,7 @@ public class EnumFieldsIndex implements Index {
 
 	public void findFieldNames() {
 		try {
-			this.fieldNames = new FieldNameFinder().findNames(this);
+			this.fieldNames = new ConstantFieldNameFinder().findNames(this);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
@@ -94,6 +94,7 @@ public class ConstantFieldNameFinder implements Opcodes {
 	private static String stringToUpperSnakeCase(String s) {
 		StringBuilder usableName = new StringBuilder();
 		boolean hasAlphabetic = false;
+		boolean prevUsable = false;
 
 		for (int j = 0; j < s.length(); j++) {
 			char c = s.charAt(j);
@@ -103,13 +104,17 @@ public class ConstantFieldNameFinder implements Opcodes {
 					hasAlphabetic = true;
 				}
 
-				if (j > 0 && Character.isUpperCase(c) && j < s.length() - 1 && Character.isLowerCase(s.charAt(j + 1))) {
+				// Add an underscore before if the current character follows another letter/number and is the start of a camel cased word
+				if (j > 0 && Character.isUpperCase(c) && j < s.length() - 1 && Character.isLowerCase(s.charAt(j + 1)) && prevUsable) {
 					usableName.append('_');
 				}
 
 				usableName.append(Character.toUpperCase(c));
-			} else {
+				prevUsable = true;
+			} else if (j > 0 && j < s.length() - 1 && prevUsable) {
+				// Replace unusable characters with underscores if they aren't at the start or end, and are following another usable character
 				usableName.append('_');
+				prevUsable = false;
 			}
 		}
 

--- a/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
@@ -140,7 +140,9 @@ public class ConstantFieldNameFinder implements Opcodes {
 				if (insnPredicate.test(stackInsn)) {
 					return stackInsn;
 				} else if (stackInsn.getOpcode() == INVOKESTATIC) {
-					return searchInsnInStack(insns, stackInsn, frames, insnPredicate);
+					if (!(frameInsn instanceof MethodInsnNode mInsn) || mInsn.owner.equals(((MethodInsnNode) stackInsn).owner)) {
+						return searchInsnInStack(insns, stackInsn, frames, insnPredicate);
+					}
 				}
 
 				lastStackInsn = stackInsn;

--- a/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
@@ -17,27 +17,21 @@
 
 package org.quiltmc.enigma_plugin.index.constant_fields;
 
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.FieldInsnNode;
-import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
-import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.SourceInterpreter;
+import org.objectweb.asm.tree.analysis.SourceValue;
 import org.quiltmc.enigma.api.translation.representation.TypeDescriptor;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.analysis.Analyzer;
-import org.objectweb.asm.tree.analysis.Frame;
-import org.objectweb.asm.tree.analysis.SourceInterpreter;
-import org.objectweb.asm.tree.analysis.SourceValue;
 import org.tinylog.Logger;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 

--- a/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
@@ -226,7 +226,14 @@ public class ConstantFieldNameFinder implements Opcodes {
 		// Insert linked names
 		for (FieldEntry linked : this.linkedFields.keySet()) {
 			FieldEntry target = this.followFieldLink(linked, fieldNames);
+			if (target == null) {
+				continue;
+			}
+
 			String name = fieldNames.get(target);
+			if (name == null) {
+				continue;
+			}
 
 			String clazz = linked.getParent().getFullName();
 			Set<String> usedNames = this.usedNamesByClass.computeIfAbsent(clazz, s -> new HashSet<>());

--- a/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
@@ -22,7 +22,9 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
 import org.objectweb.asm.tree.analysis.SourceInterpreter;
 import org.objectweb.asm.tree.analysis.SourceValue;
 import org.quiltmc.enigma.api.translation.representation.TypeDescriptor;
@@ -32,10 +34,15 @@ import org.tinylog.Logger;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class ConstantFieldNameFinder implements Opcodes {
+	private final HashMap<String, Set<String>> usedNamesByClass = new HashMap<>();
+	private final HashMap<String, Set<String>> duplicatedNamesByClass = new HashMap<>();
+	private final HashMap<FieldEntry, FieldEntry> linkedFields = new HashMap<>();
+
 	private static boolean isClassPutStatic(String owner, AbstractInsnNode insn) {
 		return insn.getOpcode() == PUTSTATIC && ((FieldInsnNode) insn).owner.equals(owner);
 	}
@@ -46,16 +53,6 @@ public class ConstantFieldNameFinder implements Opcodes {
 
 	private static boolean isCharacterUsable(char c) {
 		return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_';
-	}
-
-	private static FieldEntry followFieldLink(FieldEntry field, Map<FieldEntry, FieldEntry> linkedFields, Map<FieldEntry, String> names) {
-		if (names.containsKey(field)) {
-			return field;
-		} else if (linkedFields.containsKey(field)) {
-			return followFieldLink(linkedFields.get(field), linkedFields, names);
-		}
-
-		return null;
 	}
 
 	private static String stringToUpperSnakeCase(String s) {
@@ -87,154 +84,178 @@ public class ConstantFieldNameFinder implements Opcodes {
 		return usableName.toString().toUpperCase();
 	}
 
+	private FieldEntry followFieldLink(FieldEntry field, Map<FieldEntry, String> names) {
+		if (names.containsKey(field)) {
+			return field;
+		} else if (this.linkedFields.containsKey(field)) {
+			return followFieldLink(this.linkedFields.get(field), names);
+		}
+
+		return null;
+	}
+
+	private void clear() {
+		this.usedNamesByClass.clear();
+		this.duplicatedNamesByClass.clear();
+		this.linkedFields.clear();
+	}
+
 	public Map<FieldEntry, String> findNames(ConstantFieldIndex fieldIndex) throws Exception {
+		this.clear();
+
 		Analyzer<SourceValue> analyzer = new Analyzer<>(new SourceInterpreter());
 		Map<FieldEntry, String> fieldNames = new HashMap<>();
-		Map<String, Set<String>> usedFieldNames = new HashMap<>();
-		Map<String, Set<String>> duplicatedFieldNames = new HashMap<>();
-		Map<FieldEntry, FieldEntry> linkedFields = new HashMap<>();
 
 		for (String clazz : fieldIndex.getStaticInitializers().keySet()) {
 			var initializers = fieldIndex.getStaticInitializers().get(clazz);
 
-			for (var initializer : initializers) {
-				var frames = analyzer.analyze(clazz, initializer);
-				var instructions = initializer.instructions;
+			findNamesInInitializers(clazz, initializers, analyzer, fieldNames);
+		}
 
-				for (int i = 1; i < instructions.size(); i++) {
-					var insn = instructions.get(i);
-					var prevInsn = insn.getPrevious();
+		// Insert linked names
+		for (FieldEntry linked : this.linkedFields.keySet()) {
+			FieldEntry target = followFieldLink(linked, fieldNames);
+			String name = fieldNames.get(target);
 
-					if (!isClassPutStatic(clazz, insn)) {
-						continue;
+			String clazz = linked.getParent().getFullName();
+			Set<String> usedNames = this.usedNamesByClass.computeIfAbsent(clazz, s -> new HashSet<>());
+			Set<String> duplicatedNames = this.duplicatedNamesByClass.computeIfAbsent(clazz, s -> new HashSet<>());
+			if (!duplicatedNames.contains(name) && usedNames.add(name)) {
+				fieldNames.put(linked, name);
+			} else {
+				duplicatedNames.add(name);
+				Logger.warn("Duplicate name \"{}\" for field {}", name, linked);
+			}
+		}
+
+		return fieldNames;
+	}
+
+	private void findNamesInInitializers(String clazz, List<MethodNode> initializers, Analyzer<SourceValue> analyzer, Map<FieldEntry, String> fieldNames) throws AnalyzerException {
+		var usedNames = this.usedNamesByClass.computeIfAbsent(clazz, s -> new HashSet<>());
+		var duplicatedNames = this.duplicatedNamesByClass.computeIfAbsent(clazz, s -> new HashSet<>());
+
+		for (var initializer : initializers) {
+			var frames = analyzer.analyze(clazz, initializer);
+			var instructions = initializer.instructions;
+
+			for (int i = 1; i < instructions.size(); i++) {
+				var insn = instructions.get(i);
+				var prevInsn = insn.getPrevious();
+
+				if (!isClassPutStatic(clazz, insn)) {
+					continue;
+				}
+
+				/*
+				 * We want instructions in the form of
+				 * prevInsn: INVOKESTATIC ${clazz}.* (*)L*; || INVOKESPECIAL ${clazz}.<init> (*)V
+				 * insn:     PUTSTATIC ${clazz}.* : L*;
+				 */
+				var putStatic = (FieldInsnNode) insn;
+				if (!(prevInsn instanceof MethodInsnNode invokeInsn) || !invokeInsn.owner.equals(clazz)) {
+					continue; // Ensure the previous instruction was an invocation of one of this class' methods
+				}
+
+				if (invokeInsn.getOpcode() != INVOKESTATIC && !isInit(invokeInsn)) {
+					continue; // Ensure the invocation is either an INVOKESTATIC or a constructor invocation
+				}
+
+				// Search for a name within the frame for the invocation instruction
+				var frame = frames[i - 1];
+				String name = null;
+				for (int j = 0; j < frame.getStackSize(); j++) {
+					var value = frame.getStack(j);
+					for (var stackInsn : value.insns) {
+						if (stackInsn instanceof LdcInsnNode ldc && ldc.cst instanceof String constant && !constant.isBlank()) {
+							name = constant;
+							break;
+						}
 					}
+				}
 
-					/*
-					 * We want instructions in the form of
-					 * prevInsn: INVOKESTATIC ${clazz}.* (*)L*; || INVOKESPECIAL ${clazz}.<init> (*)V
-					 * insn:     PUTSTATIC ${clazz}.* : L*;
-					 */
-					var putStatic = (FieldInsnNode) insn;
-					if (!(prevInsn instanceof MethodInsnNode invokeInsn) || !invokeInsn.owner.equals(clazz)) {
-						continue; // Ensure the previous instruction was an invocation of one of this class' methods
-					}
-
-					if (invokeInsn.getOpcode() != INVOKESTATIC && !isInit(invokeInsn)) {
-						continue; // Ensure the invocation is either an INVOKESTATIC or a constructor invocation
-					}
-
-					// Search for a name within the frame for the invocation instruction
-					var frame = frames[i - 1];
-					String name = null;
+				if (name == null) {
+					// If we couldn't find a name, try to link this field to one from another class instead
+					FieldInsnNode otherFieldInsn = null;
 					for (int j = 0; j < frame.getStackSize(); j++) {
 						var value = frame.getStack(j);
+						AbstractInsnNode lastStackInsn = null;
 						for (var stackInsn : value.insns) {
-							if (stackInsn instanceof LdcInsnNode ldc && ldc.cst instanceof String constant && !constant.isBlank()) {
-								name = constant;
+							lastStackInsn = stackInsn;
+							if (stackInsn instanceof FieldInsnNode fieldInsn && fieldInsn.getOpcode() == GETSTATIC && !fieldInsn.owner.equals(clazz)) {
+								otherFieldInsn = fieldInsn;
 								break;
 							}
 						}
-					}
 
-					if (name == null) {
-						// If we couldn't find a name, try to link this field to one from another class instead
-						FieldInsnNode otherFieldInsn = null;
-						for (int j = 0; j < frame.getStackSize(); j++) {
-							var value = frame.getStack(j);
-							AbstractInsnNode lastStackInsn = null;
-							for (var stackInsn : value.insns) {
-								lastStackInsn = stackInsn;
+						/* Search between the last stack instruction and the invocation instruction, useful for parameters passed to a constructor
+						 * lastStackInsn: NEW * // Last instruction in the stack
+						 *                DUP
+						 *                GETSTATIC !${clazz}.* : * // Instruction we are looking for
+						 *                INVOKESPECIAL *.<init> (*)V
+						 * invokeInsn:    INVOKESPECIAL ${clazz}.<init> (L*;*)V
+						 */
+						if (otherFieldInsn == null && lastStackInsn != null) {
+							var stackInsn = lastStackInsn;
+							while ((stackInsn = stackInsn.getNext()) != null && stackInsn != invokeInsn) {
 								if (stackInsn instanceof FieldInsnNode fieldInsn && fieldInsn.getOpcode() == GETSTATIC && !fieldInsn.owner.equals(clazz)) {
 									otherFieldInsn = fieldInsn;
 									break;
 								}
 							}
-
-							/* Search between the last stack instruction and the invocation instruction, useful for parameters passed to a constructor
-							 * lastStackInsn: NEW * // Last instruction in the stack
-							 *                DUP
-							 *                GETSTATIC !${clazz}.* : * // Instruction we are looking for
-							 *                INVOKESPECIAL *.<init> (*)V
-							 * invokeInsn:    INVOKESPECIAL ${clazz}.<init> (L*;*)V
-							 */
-							if (otherFieldInsn == null && lastStackInsn != null) {
-								var stackInsn = lastStackInsn;
-								while ((stackInsn = stackInsn.getNext()) != null && stackInsn != invokeInsn) {
-									if (stackInsn instanceof FieldInsnNode fieldInsn && fieldInsn.getOpcode() == GETSTATIC && !fieldInsn.owner.equals(clazz)) {
-										otherFieldInsn = fieldInsn;
-										break;
-									}
-								}
-							}
-						}
-
-						if (otherFieldInsn != null) {
-							linkedFields.put(fieldFromInsn(putStatic), fieldFromInsn(otherFieldInsn));
-						}
-
-						continue; // Done with the current putStatic
-					}
-
-					// Remove identifier namespace
-					if (name.contains(":")) {
-						name = name.substring(name.lastIndexOf(":") + 1);
-					}
-
-					// Process a path
-					if (name.contains("/")) {
-						int separator = name.indexOf("/");
-						String first = name.substring(0, separator);
-						String last;
-
-						if (name.contains(".") && name.indexOf(".") > separator) {
-							last = name.substring(separator + 1, name.indexOf("."));
-						} else {
-							last = name.substring(separator + 1);
-						}
-
-						if (first.endsWith("s")) {
-							first = first.substring(0, first.length() - 1);
-						}
-
-						name = last + "_" + first;
-					}
-
-					var fieldName = stringToUpperSnakeCase(name);
-
-					if (fieldName == null || fieldName.isEmpty()) {
-						continue;
-					}
-
-					Set<String> usedNames = usedFieldNames.computeIfAbsent(clazz, k -> new HashSet<>());
-					Set<String> duplicatedNames = duplicatedFieldNames.computeIfAbsent(clazz, k -> new HashSet<>());
-
-					if (!duplicatedNames.contains(fieldName)) {
-						if (!usedNames.add(fieldName)) {
-							Logger.warn("Duplicate key: " + fieldName + " (" + name + ") in " + clazz);
-							duplicatedNames.add(fieldName);
-							usedNames.remove(fieldName);
 						}
 					}
 
-					if (usedNames.contains(fieldName)) {
-						fieldNames.put(fieldFromInsn(putStatic), fieldName);
+					if (otherFieldInsn != null) {
+						this.linkedFields.put(fieldFromInsn(putStatic), fieldFromInsn(otherFieldInsn));
 					}
+
+					continue; // Done with the current putStatic
+				}
+
+				// Remove identifier namespace
+				if (name.contains(":")) {
+					name = name.substring(name.lastIndexOf(":") + 1);
+				}
+
+				// Process a path
+				if (name.contains("/")) {
+					int separator = name.indexOf("/");
+					String first = name.substring(0, separator);
+					String last;
+
+					if (name.contains(".") && name.indexOf(".") > separator) {
+						last = name.substring(separator + 1, name.indexOf("."));
+					} else {
+						last = name.substring(separator + 1);
+					}
+
+					if (first.endsWith("s")) {
+						first = first.substring(0, first.length() - 1);
+					}
+
+					name = last + "_" + first;
+				}
+
+				var fieldName = stringToUpperSnakeCase(name);
+
+				if (fieldName == null || fieldName.isEmpty()) {
+					continue;
+				}
+
+				if (!duplicatedNames.contains(fieldName)) {
+					if (!usedNames.add(fieldName)) {
+						Logger.warn("Duplicate key: " + fieldName + " (" + name + ") in " + clazz);
+						duplicatedNames.add(fieldName);
+						usedNames.remove(fieldName);
+					}
+				}
+
+				if (usedNames.contains(fieldName)) {
+					fieldNames.put(fieldFromInsn(putStatic), fieldName);
 				}
 			}
 		}
-
-		// Insert linked names
-		for (FieldEntry linked : linkedFields.keySet()) {
-			FieldEntry target = followFieldLink(linked, linkedFields, fieldNames);
-			String name = fieldNames.get(target);
-
-			Set<String> usedNames = usedFieldNames.computeIfAbsent(linked.getParent().getFullName(), s -> new HashSet<>());
-			if (usedNames.add(name)) {
-				fieldNames.put(linked, name);
-			}
-		}
-
-		return fieldNames;
 	}
 
 	private static FieldEntry fieldFromInsn(FieldInsnNode insn) {

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/ConstantFieldNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/ConstantFieldNameProposer.java
@@ -21,23 +21,23 @@ import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
 import org.quiltmc.enigma_plugin.index.JarIndexer;
-import org.quiltmc.enigma_plugin.index.enum_fields.EnumFieldsIndex;
+import org.quiltmc.enigma_plugin.index.constant_fields.ConstantFieldIndex;
 
 import java.util.Map;
 
-public class EnumFieldNameProposer extends NameProposer {
-	public static final String ID = "enum_fields";
-	private final EnumFieldsIndex enumIndex;
+public class ConstantFieldNameProposer extends NameProposer {
+	public static final String ID = "constant_fields";
+	private final ConstantFieldIndex fieldIndex;
 
-	public EnumFieldNameProposer(JarIndexer index) {
+	public ConstantFieldNameProposer(JarIndexer index) {
 		super(ID);
-		this.enumIndex = index.getEnumFieldsIndex();
+		this.fieldIndex = index.getEnumFieldsIndex();
 	}
 
 	@Override
 	public void insertProposedNames(JarIndex index, Map<Entry<?>, EntryMapping> mappings) {
-		for (FieldEntry field : this.enumIndex.getFields()) {
-			String name = this.enumIndex.getName(field);
+		for (FieldEntry field : this.fieldIndex.getFields()) {
+			String name = this.fieldIndex.getName(field);
 			this.insertProposal(mappings, field, name);
 		}
 	}

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/ConstantFieldNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/ConstantFieldNameProposer.java
@@ -31,7 +31,7 @@ public class ConstantFieldNameProposer extends NameProposer {
 
 	public ConstantFieldNameProposer(JarIndexer index) {
 		super(ID);
-		this.fieldIndex = index.getEnumFieldsIndex();
+		this.fieldIndex = index.getConstantFieldIndex();
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/NameProposerService.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/NameProposerService.java
@@ -38,7 +38,7 @@ public class NameProposerService implements NameProposalService {
 
 	public NameProposerService(JarIndexer indexer, EnigmaServiceContext<NameProposalService> context) {
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_RECORDS, RecordComponentNameProposer::new);
-		this.addIfEnabled(context, indexer, Arguments.DISABLE_ENUM_FIELDS, EnumFieldNameProposer::new);
+		this.addIfEnabled(context, indexer, Arguments.DISABLE_ENUM_FIELDS, ConstantFieldNameProposer::new);
 		this.addIfEnabled(context, Arguments.DISABLE_EQUALS, EqualsNameProposer::new);
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_LOGGER, LoggerNameProposer::new);
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_CODECS, CodecNameProposer::new);

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/NameProposerService.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/NameProposerService.java
@@ -38,7 +38,7 @@ public class NameProposerService implements NameProposalService {
 
 	public NameProposerService(JarIndexer indexer, EnigmaServiceContext<NameProposalService> context) {
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_RECORDS, RecordComponentNameProposer::new);
-		this.addIfEnabled(context, indexer, Arguments.DISABLE_ENUM_FIELDS, ConstantFieldNameProposer::new);
+		this.addIfEnabled(context, indexer, Arguments.DISABLE_CONSTANT_FIELDS, ConstantFieldNameProposer::new);
 		this.addIfEnabled(context, Arguments.DISABLE_EQUALS, EqualsNameProposer::new);
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_LOGGER, LoggerNameProposer::new);
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_CODECS, CodecNameProposer::new);

--- a/testProject/profile.json
+++ b/testProject/profile.json
@@ -7,7 +7,7 @@
       {
         "id": "quiltmc:name_proposal",
         "args": {
-          "disable_enum_fields": "false",
+          "disable_constant_fields": "false",
           "disable_records": "false",
           "disable_codecs": "false",
           "disable_map_non_hashed": "true"
@@ -18,7 +18,7 @@
       {
         "id": "quiltmc:jar_index",
         "args": {
-          "disable_enum_fields": "false",
+          "disable_constant_fields": "false",
           "disable_records": "false",
           "disable_codecs": "false"
         }

--- a/testProject/src/main/java/com/example/field_names/ClassTest.java
+++ b/testProject/src/main/java/com/example/field_names/ClassTest.java
@@ -3,11 +3,19 @@ package com.example.field_names;
 public class ClassTest {
 	public static final Something FOO = create("foo");
 	public static final Something BAR = create("foo/bar");
+	public static final Something BAZ = create(create(create("foo/baz")));
 	public static final Something LOREM_IPSUM = create("baz/lorem_ipsum");
 	public static final Something AN_ID = create("example:an_id");
 	public static final Something ANOTHER_ID = create("example:foo/another_id");
+	public static final Something ONE = new Something("One");
+	public static final Something TWO = new Something(new Something("Two"));
+	public static final Something THREE = new Something(new Something(new Something("Three")));
 
 	private static Something create(String value) {
+		return new Something(value);
+	}
+
+	private static Something create(Something value) {
 		return new Something(value);
 	}
 }

--- a/testProject/src/main/java/com/example/field_names/ClassTest.java
+++ b/testProject/src/main/java/com/example/field_names/ClassTest.java
@@ -7,9 +7,9 @@ public class ClassTest {
 	public static final Something LOREM_IPSUM = create("baz/lorem_ipsum");
 	public static final Something AN_ID = create("example:an_id");
 	public static final Something ANOTHER_ID = create("example:foo/another_id");
-	public static final Something ONE = new Something("One");
-	public static final Something TWO = new Something(new Something("Two"));
-	public static final Something THREE = new Something(new Something(new Something("Three")));
+	public static final Something ONE = create(new Something("One"));
+	public static final Something TWO = create(new Something(new Something("Two")));
+	public static final Something THREE = create(new Something(new Something(new Something("Three"))));
 
 	private static Something create(String value) {
 		return new Something(value);

--- a/testProject/src/main/java/com/example/field_names/Enum2Test.java
+++ b/testProject/src/main/java/com/example/field_names/Enum2Test.java
@@ -1,0 +1,35 @@
+package com.example.field_names;
+
+import java.util.Random;
+
+public enum Enum2Test {
+	CONSTANT,
+	INT {
+		@Override
+		public double randomValue(Random random) {
+			return random.nextInt();
+		}
+	},
+	DOUBLE {
+		@Override
+		public double randomValue(Random random) {
+			return random.nextDouble();
+		}
+	},
+	EXPONENTIAL {
+		@Override
+		public double randomValue(Random random) {
+			return random.nextExponential();
+		}
+	},
+	GAUSSIAN {
+		@Override
+		public double randomValue(Random random) {
+			return random.nextGaussian();
+		}
+	};
+
+	public double randomValue(Random random) {
+		return 0;
+	}
+}


### PR DESCRIPTION
Now names are searched recursively, and strings passed to constructors are properly detected