### PR TITLE
Mojmap getter+fix tests on windows

### DIFF
--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/MojmapNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/MojmapNameProposer.java
@@ -38,7 +38,12 @@ public class MojmapNameProposer extends NameProposer {
 	private final String mojmapPath;
 	// must be static for now. nasty hack to make sure we don't read mojmaps twice
 	// we can guarantee that this is nonnull for the other proposer because jar proposal blocks dynamic proposal
-	public static EntryTree<EntryMapping> mojmaps;
+	private static EntryTree<EntryMapping> mojmaps;
+
+	@Nullable
+	public static EntryTree<EntryMapping> getMojmaps() {
+		return mojmaps;
+	}
 
 	public MojmapNameProposer(@Nullable String mojmapPath) {
 		super(ID);

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/MojmapPackageProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/MojmapPackageProposer.java
@@ -47,7 +47,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static org.quiltmc.enigma_plugin.proposal.MojmapNameProposer.mojmaps;
+import static org.quiltmc.enigma_plugin.proposal.MojmapNameProposer.getMojmaps;
 
 /**
  * Proposes Mojang's packages onto all top-level classes.
@@ -112,6 +112,7 @@ public class MojmapPackageProposer extends NameProposer {
 
 	@Override
 	public void proposeDynamicNames(EntryRemapper remapper, Entry<?> obfEntry, EntryMapping oldMapping, EntryMapping newMapping, Map<Entry<?>, EntryMapping> mappings) {
+		final EntryTree<EntryMapping> mojmaps = getMojmaps();
 		if (mojmaps != null) {
 			if (this.packageOverrides == null) {
 				if (this.packageNameOverridesPath != null) {
@@ -126,16 +127,16 @@ public class MojmapPackageProposer extends NameProposer {
 				// rename all classes as per overrides
 				var classes = remapper.getJarIndex().getIndex(EntryIndex.class).getClasses();
 				for (ClassEntry classEntry : classes) {
-					this.proposePackageName(classEntry, null, null, mappings);
+					this.proposePackageName(classEntry, null, null, mappings, mojmaps);
 				}
 			} else if (obfEntry instanceof ClassEntry classEntry) {
 				// rename class
-				this.proposePackageName(classEntry, oldMapping, newMapping, mappings);
+				this.proposePackageName(classEntry, oldMapping, newMapping, mappings, mojmaps);
 			}
 		}
 	}
 
-	private void proposePackageName(ClassEntry entry, @Nullable EntryMapping oldMapping, @Nullable EntryMapping newMapping, Map<Entry<?>, EntryMapping> mappings) {
+	private void proposePackageName(ClassEntry entry, @Nullable EntryMapping oldMapping, @Nullable EntryMapping newMapping, Map<Entry<?>, EntryMapping> mappings, EntryTree<EntryMapping> mojmaps) {
 		if (entry.isInnerClass()) {
 			return;
 		}

--- a/src/test/java/org/quiltmc/enigma_plugin/MojmapTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/MojmapTest.java
@@ -231,7 +231,7 @@ public class MojmapTest {
 
 		Path tempFile = Files.createTempFile("temp_package_overrides_moj", "json");
 
-		var entries = MojmapPackageProposer.createPackageJson(MojmapNameProposer.mojmaps);
+		var entries = MojmapPackageProposer.createPackageJson(MojmapNameProposer.getMojmaps());
 		MojmapPackageProposer.writePackageJson(tempFile, entries);
 
 		String expected = Files.readString(Path.of("./src/test/resources/mojmap_test/expected.json"));

--- a/src/test/java/org/quiltmc/enigma_plugin/MojmapTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/MojmapTest.java
@@ -52,6 +52,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -81,7 +82,22 @@ public class MojmapTest {
 	private static final Path uppercases = invalidOverrides.resolve("uppercases.json");
 	private static final Path validOverrides = invalidOverrides.resolve("valid_overrides.json");
 
+	private static final Pattern UNWANTED_LINE_ENDING = Pattern.compile("\\r\\n?");
+
 	private static EnigmaProject project;
+
+	private static String deWindowsPath(String path) {
+		final String osName = System.getProperty("os.name");
+		if (osName != null && osName.toLowerCase().contains("win")) {
+			return path.replace('\\', '/');
+		} else {
+			return path;
+		}
+	}
+
+	private static String toNewLineEndings(String string) {
+		return UNWANTED_LINE_ENDING.matcher(string).replaceAll("\n");
+	}
 
 	@BeforeAll
 	static void downloadMojmaps() throws IOException {
@@ -150,8 +166,8 @@ public class MojmapTest {
 					}
 				}""";
 
-		profileString = profileString.replace("{MOJMAP_PATH}", mojmapPath.toString());
-		profileString = profileString.replace("{OVERRIDES_PATH}", overridesPath.toString());
+		profileString = profileString.replace("{MOJMAP_PATH}", deWindowsPath(mojmapPath.toString()));
+		profileString = profileString.replace("{OVERRIDES_PATH}", deWindowsPath(overridesPath.toString()));
 
 		var profile = EnigmaProfile.parse(new StringReader(profileString));
 
@@ -206,7 +222,7 @@ public class MojmapTest {
 		String expected = Files.readString(Path.of("./src/test/resources/mojmap_test/example_mappings_empty.json"));
 		String actual = Files.readString(tempFile);
 
-		Assertions.assertEquals(expected, actual);
+		Assertions.assertEquals(toNewLineEndings(expected), toNewLineEndings(actual));
 	}
 
 	@Test
@@ -221,7 +237,7 @@ public class MojmapTest {
 		String expected = Files.readString(Path.of("./src/test/resources/mojmap_test/expected.json"));
 		String actual = Files.readString(tempFile);
 
-		Assertions.assertEquals(expected, actual);
+		Assertions.assertEquals(toNewLineEndings(expected), toNewLineEndings(actual));
 	}
 
 	@Test
@@ -241,7 +257,7 @@ public class MojmapTest {
 		String expected = Files.readString(newOverrides);
 		String actual = Files.readString(tempFile);
 
-		Assertions.assertEquals(expected, actual);
+		Assertions.assertEquals(toNewLineEndings(expected), toNewLineEndings(actual));
 	}
 
 	@Test


### PR DESCRIPTION
fixes tests on windows [line endings and path separators] (they should still work on unix but definitely check!)
makes the static `mojmaps` field private with a getter (I tried and failed to reduce hacks more than that)