### PR TITLE
Verify simple type existence

### DIFF
--- a/src/main/java/org/quiltmc/enigma_plugin/Arguments.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/Arguments.java
@@ -35,6 +35,7 @@ public class Arguments {
 	public static final String DISABLE_MAPPING_MERGE = "disable_mapping_merge";
 	public static final String CUSTOM_CODECS = "custom_codecs";
 	public static final String SIMPLE_TYPE_FIELD_NAMES_PATH = "simple_type_field_names_path";
+	public static final String SIMPLE_TYPE_FIELD_NAMES_TYPE_VERIFICATION = "simple_type_field_names_type_verification";
 	public static final String MERGED_MAPPING_PATH = "merged_mapping_path";
 	public static final String PACKAGE_NAME_OVERRIDES_PATH = "package_name_overrides_path";
 

--- a/src/main/java/org/quiltmc/enigma_plugin/index/simple_type_single/SimpleTypeFieldNamesRegistry.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/simple_type_single/SimpleTypeFieldNamesRegistry.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 public class SimpleTypeFieldNamesRegistry {
 	private final Path path;
@@ -46,6 +47,10 @@ public class SimpleTypeFieldNamesRegistry {
 		return this.entries.get(type);
 	}
 
+	public Stream<String> streamTypes() {
+		return this.entries.keySet().stream();
+	}
+
 	public void read() {
 		try (var reader = JsonReader.json5(this.path)) {
 			if (reader.peek() != JsonToken.BEGIN_OBJECT) {
@@ -56,6 +61,11 @@ public class SimpleTypeFieldNamesRegistry {
 
 			while (reader.hasNext()) {
 				String type = reader.nextName();
+
+				if (type.equals("$schema")) {
+					reader.skipValue();
+					continue;
+				}
 
 				if (this.entries.containsKey(type)) {
 					throw new IllegalArgumentException("Duplicate type " + type);

--- a/src/main/java/org/quiltmc/enigma_plugin/index/simple_type_single/SimpleTypeSingleIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/simple_type_single/SimpleTypeSingleIndex.java
@@ -60,7 +60,7 @@ public class SimpleTypeSingleIndex extends Index {
 	private final Map<LocalVariableEntry, List<String>> parameterFallbacks = new HashMap<>();
 	private final Map<FieldEntry, String> fields = new HashMap<>();
 	private final Map<ClassNode, Map<String, FieldBuildingEntry>> fieldCache = new HashMap<>();
-	private final Set<String> unverifiedTypes;
+	private final Set<String> unverifiedTypes = new HashSet<>();
 
 	private SimpleTypeFieldNamesRegistry registry;
 	private InheritanceIndex inheritance;
@@ -68,8 +68,6 @@ public class SimpleTypeSingleIndex extends Index {
 
 	public SimpleTypeSingleIndex() {
 		super(null);
-
-		this.unverifiedTypes = new HashSet<>();
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/enigma_plugin/index/simple_type_single/SimpleTypeSingleIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/simple_type_single/SimpleTypeSingleIndex.java
@@ -76,9 +76,6 @@ public class SimpleTypeSingleIndex extends Index {
 	public void withContext(EnigmaServiceContext<JarIndexerService> context) {
 		super.withContext(context);
 
-		this.loadRegistry(context.getSingleArgument(Arguments.SIMPLE_TYPE_FIELD_NAMES_PATH)
-				.map(context::getPath).orElse(null));
-
 		this.typeVerification = context.getSingleArgument(Arguments.SIMPLE_TYPE_FIELD_NAMES_TYPE_VERIFICATION)
 			.map(value -> {
 				try {
@@ -98,6 +95,9 @@ public class SimpleTypeSingleIndex extends Index {
 				}
 			})
 			.orElse(TypeVerification.DEFAULT);
+
+		this.loadRegistry(context.getSingleArgument(Arguments.SIMPLE_TYPE_FIELD_NAMES_PATH)
+				.map(context::getPath).orElse(null));
 	}
 
 	@Override
@@ -115,7 +115,9 @@ public class SimpleTypeSingleIndex extends Index {
 		this.registry.read();
 
 		this.unverifiedTypes.clear();
-		this.registry.streamTypes().forEach(this.unverifiedTypes::add);
+		if (this.typeVerification != TypeVerification.NONE) {
+			this.registry.streamTypes().forEach(this.unverifiedTypes::add);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/SimpleTypeFieldNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/SimpleTypeFieldNameProposer.java
@@ -38,6 +38,8 @@ public class SimpleTypeFieldNameProposer extends NameProposer {
 
 	@Override
 	public void insertProposedNames(Enigma enigma, JarIndex index, Map<Entry<?>, EntryMapping> mappings) {
+		this.index.verifyTypes();
+
 		for (FieldEntry field : this.index.getFields()) {
 			String name = this.index.getField(field);
 

--- a/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
@@ -35,7 +35,9 @@ import org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntr
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.util.validation.ValidationContext;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Path;
 
 public class NameProposalTest {
@@ -45,6 +47,10 @@ public class NameProposalTest {
 
 	@BeforeAll
 	public static void setupEnigma() throws IOException {
+		PrintStream originalErr = System.err;
+		ByteArrayOutputStream testErr = new ByteArrayOutputStream();
+		System.setErr(new PrintStream(testErr));
+
 		var profile = EnigmaProfile.read(PROFILE);
 		var enigma = Enigma.builder().setProfile(profile).build();
 
@@ -53,6 +59,11 @@ public class NameProposalTest {
 
 		// Manually fire dynamic proposals
 		remapper.insertDynamicallyProposedMappings(null, null, null);
+
+		// simple_type_field_names_type_verification warning
+		Assertions.assertTrue(testErr.toString().contains("[WARN]: The following simple type field name was not encountered: not/present"));
+
+		System.setErr(originalErr);
 	}
 
 	public static void assertProposal(String name, Entry<?> entry) {

--- a/src/testInputs/resources/profile.json
+++ b/src/testInputs/resources/profile.json
@@ -20,7 +20,8 @@
           "disable_constant_fields": "false",
           "disable_records": "false",
           "disable_codecs": "false",
-          "simple_type_field_names_path": "./simple_type_field_names.json5"
+          "simple_type_field_names_path": "./simple_type_field_names.json5",
+          "simple_type_field_names_type_verification": "WARN"
         }
       }
     ]

--- a/src/testInputs/resources/simple_type_field_names.json5
+++ b/src/testInputs/resources/simple_type_field_names.json5
@@ -88,5 +88,6 @@
     "com/a/b/l": { // ValueE
         local_name: "valueE",
         exclusive: true
-    }
+    },
+    "not/present": "missing"
 }


### PR DESCRIPTION
Allows tracking which simple types have been encountered and warning or throwing if any aren't.

Adds `"simple_type_field_names_type_verification"` argument with possible values `NONE`, `WARN`, and `THROW`; default is `WARN`.

Helps find simple type entries for classes that were removed or whose obfuscated name has changed.