### PR TITLE
prevent `ConstantFieldNameFinder` from finding invalid java identifiers

### DIFF
--- a/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/constant_fields/ConstantFieldNameFinder.java
@@ -53,6 +53,20 @@ public class ConstantFieldNameFinder implements Opcodes {
 		return insn.getOpcode() == INVOKESPECIAL && ((MethodInsnNode) insn).name.equals("<init>");
 	}
 
+	private static boolean isValidJavaIdentifier(String id) {
+		if (id.isEmpty() || !Character.isJavaIdentifierStart(id.charAt(0))) {
+			return false;
+		}
+
+		for (int i = 1; i < id.length(); i++) {
+			if (!Character.isJavaIdentifierPart(id.charAt(i))) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	private static String processIdentifierPath(String name) {
 		if (name == null) {
 			return null;
@@ -192,7 +206,7 @@ public class ConstantFieldNameFinder implements Opcodes {
 				String s = processIdentifierPath(name);
 				var fieldName = CasingUtil.toSafeScreamingSnakeCase(s);
 
-				if (fieldName == null || fieldName.isEmpty()) {
+				if (fieldName == null || !isValidJavaIdentifier(fieldName)) {
 					continue;
 				}
 

--- a/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
@@ -125,6 +125,8 @@ public class NameProposalTest {
 		assertProposal("ONE", new FieldEntry(classEntry, "g", desc));
 		assertProposal("TWO", new FieldEntry(classEntry, "h", desc));
 		assertProposal("THREE", new FieldEntry(classEntry, "i", desc));
+		// don't propose 123ABC for INVALID
+		assertNotProposed(field(classEntry, "j", desc.toString()));
 
 		var class2Entry = new ClassEntry("com/a/a/a");
 

--- a/src/testInputs/java/com/example/field_names/ClassTest.java
+++ b/src/testInputs/java/com/example/field_names/ClassTest.java
@@ -10,6 +10,7 @@ public class ClassTest {
 	public static final Something ONE = create(new Something("One"));
 	public static final Something TWO = create(new Something(new Something("Two")));
 	public static final Something THREE = create(new Something(new Something(new Something("Three"))));
+	public static final Something INVALID = create("123ABC");
 
 	private static Something create(String value) {
 		return new Something(value);


### PR DESCRIPTION
For cases like strings that begin with a number.