### PR TITLE
Non hashed check

### DIFF
--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/ConstructorParamsNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/ConstructorParamsNameProposer.java
@@ -18,6 +18,7 @@ package org.quiltmc.enigma_plugin.proposal;
 
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
+import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
@@ -49,13 +50,13 @@ public class ConstructorParamsNameProposer extends NameProposer {
 					continue;
 				}
 
-				this.insertDynamicProposal(mappings, parameter, newMapping);
+				this.insertDynamicProposal(mappings, parameter, this.mappingOrNonHashed(parameter, newMapping, TokenType.DYNAMIC_PROPOSED));
 			}
 		} else if (obfEntry instanceof LocalVariableEntry parameter && this.index.isParameterLinked(parameter)) {
 			FieldEntry linkedField = this.index.getLinkedField(parameter);
 
 			if (!this.hasJarProposal(remapper, linkedField)) {
-				this.insertDynamicProposal(mappings, linkedField, newMapping);
+				this.insertDynamicProposal(mappings, linkedField, this.mappingOrNonHashed(linkedField, newMapping, TokenType.DYNAMIC_PROPOSED));
 			}
 
 			for (LocalVariableEntry param : this.index.getParametersForField(linkedField)) {
@@ -64,7 +65,7 @@ public class ConstructorParamsNameProposer extends NameProposer {
 				}
 
 				if (param != parameter) {
-					this.insertDynamicProposal(mappings, param, newMapping);
+					this.insertDynamicProposal(mappings, param, this.mappingOrNonHashed(param, newMapping, TokenType.DYNAMIC_PROPOSED));
 				}
 			}
 		} else if (obfEntry == null) {
@@ -75,7 +76,7 @@ public class ConstructorParamsNameProposer extends NameProposer {
 				}
 
 				FieldEntry linkedField = this.index.getLinkedField(parameter);
-				EntryMapping mapping = remapper.getMapping(linkedField);
+				EntryMapping mapping = this.getMappingOrNonHashed(linkedField, remapper, TokenType.DYNAMIC_PROPOSED);
 
 				this.insertDynamicProposal(mappings, parameter, mapping);
 			}

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegateParametersNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegateParametersNameProposer.java
@@ -65,7 +65,7 @@ public class DelegateParametersNameProposer extends NameProposer {
 			return name;
 		}
 
-		var mapping = this.getMappingOrNonHashed(entry, remapper, TokenType.DYNAMIC_PROPOSED);
+		var mapping = remapper.getMapping(entry);
 		if (mapping.targetName() != null && shouldNotIgnoreMapping(mapping)) {
 			return mapping.targetName();
 		} else {

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegateParametersNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegateParametersNameProposer.java
@@ -18,6 +18,7 @@ package org.quiltmc.enigma_plugin.proposal;
 
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
+import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
@@ -64,11 +65,11 @@ public class DelegateParametersNameProposer extends NameProposer {
 			return name;
 		}
 
-		var mapping = remapper.getMapping(entry);
+		var mapping = this.getMappingOrNonHashed(entry, remapper, TokenType.DYNAMIC_PROPOSED);
 		if (mapping.targetName() != null && shouldNotIgnoreMapping(mapping)) {
 			return mapping.targetName();
 		} else {
-			mapping = mappings.get(entry);
+			mapping = this.mappingOrNonHashed(entry, mappings.get(entry), TokenType.DYNAMIC_PROPOSED);
 			if (mapping != null && mapping.targetName() != null && shouldNotIgnoreMapping(mapping)) {
 				return mapping.targetName();
 			} else {
@@ -131,11 +132,7 @@ public class DelegateParametersNameProposer extends NameProposer {
 					this.insertDynamicProposal(mappings, parameterNames.get(name), name);
 				}
 			}
-
-			return;
-		}
-
-		if (obfEntry instanceof LocalVariableEntry paramEntry) {
+		} else if (obfEntry instanceof LocalVariableEntry paramEntry) {
 			String name;
 			if (newMapping.targetName() != null) {
 				name = newMapping.targetName();

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/GetterSetterNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/GetterSetterNameProposer.java
@@ -18,6 +18,7 @@ package org.quiltmc.enigma_plugin.proposal;
 
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
+import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
@@ -67,7 +68,7 @@ public class GetterSetterNameProposer extends NameProposer {
 				}
 
 				FieldEntry linkedField = this.index.getLinkedField(method);
-				EntryMapping mapping = remapper.getMapping(linkedField);
+				EntryMapping mapping = this.getMappingOrNonHashed(linkedField, remapper, TokenType.DYNAMIC_PROPOSED);
 				var newName = getMethodName(mapping.targetName(), method);
 
 				if (newName == null) {
@@ -83,7 +84,7 @@ public class GetterSetterNameProposer extends NameProposer {
 				}
 
 				FieldEntry linkedField = this.index.getLinkedField(parameter);
-				EntryMapping mapping = remapper.getMapping(linkedField);
+				EntryMapping mapping = this.getMappingOrNonHashed(linkedField, remapper, TokenType.DYNAMIC_PROPOSED);
 				var newName = mapping.targetName();
 
 				if (newName == null || newName.isEmpty()) {
@@ -93,11 +94,8 @@ public class GetterSetterNameProposer extends NameProposer {
 				this.insertDynamicProposal(mappings, parameter, newName);
 			}
 
-			return;
-		}
-
-		if (obfEntry instanceof FieldEntry field && this.index.fieldHasLinks(field)) {
-			var name = newMapping.targetName();
+		} else if (obfEntry instanceof FieldEntry field && this.index.fieldHasLinks(field)) {
+			var name = this.mappingOrNonHashed(field, newMapping, TokenType.DYNAMIC_PROPOSED).targetName();
 
 			for (Entry<?> link : this.index.getFieldLinks(field)) {
 				if (this.hasJarProposal(remapper, link)) {

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/GetterSetterNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/GetterSetterNameProposer.java
@@ -93,7 +93,6 @@ public class GetterSetterNameProposer extends NameProposer {
 
 				this.insertDynamicProposal(mappings, parameter, newName);
 			}
-
 		} else if (obfEntry instanceof FieldEntry field && this.index.fieldHasLinks(field)) {
 			var name = this.mappingOrNonHashed(field, newMapping, TokenType.DYNAMIC_PROPOSED).targetName();
 

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/MappingMergePackageProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/MappingMergePackageProposer.java
@@ -25,6 +25,7 @@ import org.quiltmc.enigma.api.analysis.index.jar.EntryIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.analysis.index.mapping.MappingsIndex;
 import org.quiltmc.enigma.api.analysis.index.mapping.PackageIndex;
+import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
@@ -152,7 +153,7 @@ public class MappingMergePackageProposer extends NameProposer {
 		String target;
 		String obfPackage = mergeTarget.substring(0, mergeTarget.lastIndexOf('/'));
 
-		if (newMapping != null && newMapping.targetName() != null) {
+		if (this.mappingOrNonHashed(entry, newMapping, TokenType.DYNAMIC_PROPOSED).targetName() != null) {
 			target = mergeTarget.substring(0, mergeTarget.lastIndexOf('/'))
 				+ newMapping.targetName().substring(newMapping.targetName().lastIndexOf('/'));
 		} else {

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/MappingMergePackageProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/MappingMergePackageProposer.java
@@ -153,9 +153,15 @@ public class MappingMergePackageProposer extends NameProposer {
 		String target;
 		String obfPackage = mergeTarget.substring(0, mergeTarget.lastIndexOf('/'));
 
-		if (this.mappingOrNonHashed(entry, newMapping, TokenType.DYNAMIC_PROPOSED).targetName() != null) {
-			target = mergeTarget.substring(0, mergeTarget.lastIndexOf('/'))
-				+ newMapping.targetName().substring(newMapping.targetName().lastIndexOf('/'));
+		final EntryMapping mapping = this.mappingOrNonHashed(entry, newMapping, TokenType.DYNAMIC_PROPOSED);
+		if (mapping.targetName() != null) {
+			int mappingPackageEnd = mapping.targetName().lastIndexOf('/');
+			if (mappingPackageEnd >= 0) {
+				target = mergeTarget.substring(0, mergeTarget.lastIndexOf('/'))
+					+ mapping.targetName().substring(mappingPackageEnd);
+			} else {
+				target = mergeTarget;
+			}
 		} else {
 			target = mergeTarget;
 		}

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/NameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/NameProposer.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.enigma_plugin.proposal;
 
+import org.jetbrains.annotations.Nullable;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.source.TokenType;
@@ -23,6 +24,7 @@ import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 import org.quiltmc.enigma_plugin.QuiltEnigmaPlugin;
+import org.quiltmc.enigma_plugin.util.EntryUtil;
 
 import java.util.Map;
 
@@ -87,5 +89,13 @@ public abstract class NameProposer {
 	public abstract void insertProposedNames(Enigma enigma, JarIndex index, Map<Entry<?>, EntryMapping> mappings);
 
 	public void proposeDynamicNames(EntryRemapper remapper, Entry<?> obfEntry, EntryMapping oldMapping, EntryMapping newMapping, Map<Entry<?>, EntryMapping> mappings) {
+	}
+
+	public EntryMapping getMappingOrNonHashed(Entry<?> entry, EntryRemapper remapper, TokenType type) {
+		return EntryUtil.getMappingOrNonHashed(entry, remapper, type, this.getSourcePluginId());
+	}
+
+	public EntryMapping mappingOrNonHashed(Entry<?> entry, @Nullable EntryMapping mapping, TokenType type) {
+		return EntryUtil.mappingOrNonHashed(entry, mapping, type, this.getSourcePluginId());
 	}
 }

--- a/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
@@ -37,10 +37,8 @@ public final class EntryUtil {
 
 	public static EntryMapping mappingOrNonHashed(Entry<?> entry, @Nullable EntryMapping mapping, TokenType type, String sourcePluginId) {
 		if (mapping == null) {
-			mapping = EntryMapping.OBFUSCATED;
-		}
-
-		if (mapping.targetName() == null) {
+			return EntryMapping.OBFUSCATED;
+		} else if (mapping.targetName() == null) {
 			String name = getNonHashedNameOrNull(entry);
 			return name == null ? mapping : new EntryMapping(name, null, type, sourcePluginId);
 		} else {

--- a/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
@@ -1,0 +1,54 @@
+package org.quiltmc.enigma_plugin.util;
+
+import org.jetbrains.annotations.Nullable;
+import org.quiltmc.enigma.api.source.TokenType;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
+import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.Entry;
+import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
+
+public final class EntryUtil {
+	private EntryUtil() {
+		throw new UnsupportedOperationException();
+	}
+
+	public static EntryMapping getMappingOrNonHashed(Entry<?> entry, EntryRemapper remapper, TokenType type, String sourcePluginId) {
+		final EntryMapping mapping = remapper.getMapping(entry);
+		return mappingOrNonHashed(entry, mapping, type, sourcePluginId);
+	}
+
+	public static EntryMapping mappingOrNonHashed(Entry<?> entry, @Nullable EntryMapping mapping, TokenType type, String sourcePluginId) {
+		if (mapping == null) {
+			return EntryMapping.OBFUSCATED;
+		} else if (mapping.targetName() == null) {
+			String name = getNonHashedNameOrNull(entry);
+			return name == null ? mapping : new EntryMapping(name, null, type, sourcePluginId);
+		} else {
+			return mapping;
+		}
+	}
+
+	@Nullable
+	public static String getNonHashedNameOrNull(Entry<?> entry) {
+		String name = entry.getName();
+		if (entry instanceof FieldEntry) {
+			return name.startsWith("f_") ? null : name;
+		} else if (entry instanceof MethodEntry method) {
+			return name.startsWith("m_") || method.isConstructor() ? null : name;
+		} else if (entry instanceof ClassEntry clazz) {
+			return clazz.getSimpleName().startsWith("C_") ? null : getClassName(clazz);
+		} else {
+			return null;
+		}
+	}
+
+	private static String getClassName(ClassEntry clazz) {
+		if (clazz.getParent() == null) {
+			return clazz.getFullName();
+		} else {
+			return clazz.getSimpleName();
+		}
+	}
+}

--- a/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
@@ -54,17 +54,9 @@ public final class EntryUtil {
 		} else if (entry instanceof MethodEntry method) {
 			return name.startsWith("m_") || method.isConstructor() ? null : name;
 		} else if (entry instanceof ClassEntry clazz) {
-			return clazz.getSimpleName().startsWith("C_") ? null : getClassName(clazz);
+			return clazz.getSimpleName().startsWith("C_") ? null : clazz.getName();
 		} else {
 			return null;
-		}
-	}
-
-	private static String getClassName(ClassEntry clazz) {
-		if (clazz.getParent() == null) {
-			return clazz.getFullName();
-		} else {
-			return clazz.getSimpleName();
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
@@ -37,8 +37,10 @@ public final class EntryUtil {
 
 	public static EntryMapping mappingOrNonHashed(Entry<?> entry, @Nullable EntryMapping mapping, TokenType type, String sourcePluginId) {
 		if (mapping == null) {
-			return EntryMapping.OBFUSCATED;
-		} else if (mapping.targetName() == null) {
+			mapping = EntryMapping.OBFUSCATED;
+		}
+
+		if (mapping.targetName() == null) {
 			String name = getNonHashedNameOrNull(entry);
 			return name == null ? mapping : new EntryMapping(name, null, type, sourcePluginId);
 		} else {

--- a/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/util/EntryUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.enigma_plugin.util;
 
 import org.jetbrains.annotations.Nullable;


### PR DESCRIPTION
Restores some of the behavior inadvertently removed with `NonHashedNameProposer`.

Also fixes a bug where `NonHashedNameProposer` named classes using `getFullName()` instead of `getName()`, which meant inner classes were named like `com.package.Outer$Inner` instead of just `Inner`.

Solves code diffs when updating plugin in qmap (except for those caused by the above bug, where the old mapping is wrong).

I updated all dynamic proposers except `ConflictFixProposer`; the code diffs are solved without updating it, and I'm not sure if updating it is necessary.