### PR TITLE
Add delegating method proposer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,12 @@ final EXEC = objects.newInstance(ExecProvider).operations
 
 version = version + (ENV.GITHUB_ACTIONS ? '' : '+local')
 
+interface ArchiveProvider {
+	@javax.inject.Inject
+	ArchiveOperations getOperations()
+}
+final ARCHIVE = objects.newInstance(ArchiveProvider).operations
+
 sourceSets {
 	testInputs
 }
@@ -105,6 +111,8 @@ tasks.register('testInputsJar', Jar) {
 
 tasks.register('obfuscateTestInputs', proguard.gradle.ProGuardTask) {
 	dependsOn testInputsJar
+	final File obfExtractionDest = new File(obfJar.parent, "obf-extracted")
+	outputs.dir(obfExtractionDest)
 
 	verbose
 	injars testInputsJar
@@ -127,6 +135,16 @@ tasks.register('obfuscateTestInputs', proguard.gradle.ProGuardTask) {
 	keepattributes 'Signature'
 	keepattributes 'Record'
 	printmapping 'build/obf/obf.txt'
+
+	doLast {
+		obfExtractionDest.deleteDir()
+
+		ARCHIVE.zipTree(obfJar).visit { FileVisitDetails details ->
+			details.copyTo(
+				new File(obfExtractionDest.toString(), details.getRelativePath().getPathString())
+			)
+		}
+	}
 }
 
 tasks.test.dependsOn obfuscateTestInputs, processTestInputsResources

--- a/src/main/java/org/quiltmc/enigma_plugin/Arguments.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/Arguments.java
@@ -31,6 +31,7 @@ public class Arguments {
 	public static final String DISABLE_GETTER_SETTER = "disable_getter_setter";
 	public static final String DISABLE_CODECS = "disable_codecs";
 	public static final String DISABLE_DELEGATE_PARAMS = "disable_delegate_params";
+	public static final String DISABLE_DELEGATING_METHODS = "disable_delegating_methods";
 	public static final String DISABLE_CONFLICT_FIXER = "disable_conflict_fixer";
 	public static final String DISABLE_MAPPING_MERGE = "disable_mapping_merge";
 	public static final String CUSTOM_CODECS = "custom_codecs";

--- a/src/main/java/org/quiltmc/enigma_plugin/index/CodecIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/CodecIndex.java
@@ -236,7 +236,7 @@ public class CodecIndex extends Index {
 
 			// Try to find and name the field from the getter
 			AsmUtil.getMethod(parent, getterHandle.getName(), getterHandle.getDesc())
-					.flatMap(m -> AsmUtil.getFieldFromGetter(parent, m))
+					.flatMap(m -> AsmUtil.getOwnedFieldFromGetter(parent, m))
 					.ifPresent(f -> {
 						var fieldEntry = new FieldEntry(parentEntry, f.name, new TypeDescriptor(f.desc));
 						this.fieldNames.put(fieldEntry, camelCaseName);
@@ -272,7 +272,7 @@ public class CodecIndex extends Index {
 
 				// Try to find and name the field from the getter
 				AsmUtil.getMethod(parent, methodInsn.name, methodInsn.desc)
-						.flatMap(m -> AsmUtil.getFieldFromGetter(parent, m))
+						.flatMap(m -> AsmUtil.getOwnedFieldFromGetter(parent, m))
 						.ifPresent(f -> {
 							var fieldEntry = new FieldEntry(parentEntry, f.name, new TypeDescriptor(f.desc));
 							this.fieldNames.put(fieldEntry, camelCaseName);

--- a/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
@@ -102,12 +102,17 @@ public class DelegatingMethodIndex extends Index {
 			return Optional.empty();
 		}
 
-		final int lastOp = method.instructions.getLast().getOpcode();
+		final AbstractInsnNode lastInstruction = method.instructions.getLast();
+		if (lastInstruction == null) {
+			return Optional.empty();
+		}
+
+		final int lastOp = lastInstruction.getOpcode();
 		if (lastOp < IRETURN || lastOp > RETURN) {
 			return Optional.empty();
 		}
 
-		if (!(method.instructions.getLast().getPrevious() instanceof MethodInsnNode lastCall)) {
+		if (!(lastInstruction.getPrevious() instanceof MethodInsnNode lastCall)) {
 			return Optional.empty();
 		}
 

--- a/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
@@ -52,37 +52,31 @@ public class DelegatingMethodIndex extends Index {
 
 	@Override
 	public void visitClassNode(ClassProvider classProvider, ClassNode clazz) {
-		// DEBUG TODO
-		if (clazz.name.equals("com/a/f")) {
-			final ClassEntry classEntry = new ClassEntry(clazz.name);
-			final Map<MethodEntry, Set<List<TypeDescriptor>>> conflictingDelegaterParamDescriptorsByDelegate = new HashMap<>();
-			for (final MethodNode method : clazz.methods) {
-				this.getDelegation(classProvider, clazz, classEntry, method).ifPresent(delegation -> {
-					final List<MethodEntry> delegaters = this.delegatersByDelegate.get(delegation.delegate);
-					if (delegaters != null) {
-						if (delegaters.removeIf(delegation.delegater::canConflictWith)) {
-							// new conflict
-							conflictingDelegaterParamDescriptorsByDelegate
-									.computeIfAbsent(delegation.delegate, ignored -> new HashSet<>())
-									.add(delegation.delegater.getDesc().getTypeDescs());
-						} else {
-							final Set<List<TypeDescriptor>> conflictParamsDescriptors =
-									conflictingDelegaterParamDescriptorsByDelegate.getOrDefault(delegation.delegate, Set.of());
-							if (!conflictParamsDescriptors.contains(delegation.delegater.getDesc().getTypeDescs())) {
-								delegaters.add(delegation.delegater);
-							}
-							// else additional conflict
-						}
+		final ClassEntry classEntry = new ClassEntry(clazz.name);
+		final Map<MethodEntry, Set<List<TypeDescriptor>>> conflictingDelegaterParamDescriptorsByDelegate = new HashMap<>();
+		for (final MethodNode method : clazz.methods) {
+			this.getDelegation(classProvider, clazz, classEntry, method).ifPresent(delegation -> {
+				final List<MethodEntry> delegaters = this.delegatersByDelegate.get(delegation.delegate);
+				if (delegaters != null) {
+					if (delegaters.removeIf(delegation.delegater::canConflictWith)) {
+						// new conflict
+						conflictingDelegaterParamDescriptorsByDelegate
+								.computeIfAbsent(delegation.delegate, ignored -> new HashSet<>())
+								.add(delegation.delegater.getDesc().getTypeDescs());
 					} else {
-						final List<MethodEntry> newDelegaters = new ArrayList<>();
-						newDelegaters.add(delegation.delegater);
-						this.delegatersByDelegate.put(delegation.delegate, newDelegaters);
+						final Set<List<TypeDescriptor>> conflictParamsDescriptors =
+								conflictingDelegaterParamDescriptorsByDelegate.getOrDefault(delegation.delegate, Set.of());
+						if (!conflictParamsDescriptors.contains(delegation.delegater.getDesc().getTypeDescs())) {
+							delegaters.add(delegation.delegater);
+						}
+						// else additional conflict
 					}
-				});
-			}
-			// DEBUG TODO
-			int i = 0;
-			byte b = 0;
+				} else {
+					final List<MethodEntry> newDelegaters = new ArrayList<>();
+					newDelegaters.add(delegation.delegater);
+					this.delegatersByDelegate.put(delegation.delegate, newDelegaters);
+				}
+			});
 		}
 	}
 
@@ -121,19 +115,6 @@ public class DelegatingMethodIndex extends Index {
 
 		if (delegateEntry.canConflictWith(delegaterEntry)) {
 			return Optional.empty();
-		}
-
-		final int lastDelegateParamIndex = delegateParams.get(delegateParams.size() - 1).getIndex();
-
-		// DEBUG TODO
-		final List<AbstractInsnNode> instructions = new ArrayList<>();
-		method.instructions.forEach(instructions::add);
-		if (method.name.equals("a") && method.desc.equals("(IJ)Ljava/lang/String;")) {
-			int i = 0;
-		}
-
-		if (method.name.equals("e") && method.desc.equals("(Ljava/lang/Object;I)F")) {
-			int i = 0;
 		}
 
 		AbstractInsnNode prevInstruction = lastCall.getPrevious();
@@ -179,8 +160,6 @@ public class DelegatingMethodIndex extends Index {
 
 			prevInstruction = prevInstruction.getPrevious();
 		}
-		// DEBUG TODO
-		instructions.get(0);
 
 		return Optional.of(new Delegation(delegateEntry, delegaterEntry));
 	}

--- a/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
@@ -1,4 +1,4 @@
-package org.quiltmc.enigma_plugin.index.delegating_method;
+package org.quiltmc.enigma_plugin.index;
 
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
@@ -14,8 +14,6 @@ import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma_plugin.Arguments;
-import org.quiltmc.enigma_plugin.index.GetterSetterIndex;
-import org.quiltmc.enigma_plugin.index.Index;
 import org.quiltmc.enigma_plugin.util.AsmUtil;
 
 import java.util.ArrayList;
@@ -232,5 +230,5 @@ public class DelegatingMethodIndex extends Index {
 		return method.parameters == null ? 0 : method.parameters.size();
 	}
 
-	static record Delegation(MethodEntry delegate, MethodEntry delegater) { }
+	record Delegation(MethodEntry delegate, MethodEntry delegater) { }
 }

--- a/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.enigma_plugin.index;
 
 import org.objectweb.asm.tree.AbstractInsnNode;

--- a/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodIndex.java
@@ -85,6 +85,7 @@ public class DelegatingMethodIndex extends Index {
 						if (!conflictParamsDescriptors.contains(delegation.delegater.getDesc().getTypeDescs())) {
 							delegaters.add(delegation.delegater);
 						}
+
 						// else additional conflict
 					}
 				} else {
@@ -140,13 +141,14 @@ public class DelegatingMethodIndex extends Index {
 			if (prevOp < ILOAD || prevOp > SALOAD) {
 				if (prevOp >= ISTORE && prevOp <= SASTORE) {
 					if (
-						// do not allow storing to any array
-						prevOp > ASTORE
-							// only allow storing to locals
-							|| !(prevInstruction instanceof VarInsnNode)
+							// do not allow storing to any array
+							prevOp > ASTORE
+								// only allow storing to locals
+								|| !(prevInstruction instanceof VarInsnNode)
 					) {
 						return Optional.empty();
 					}
+
 					// else storing local: OK
 				} else if (prevInstruction instanceof MethodInsnNode call) {
 					if (!isPrimitiveBoxOrUnbox(call)) {
@@ -160,15 +162,18 @@ public class DelegatingMethodIndex extends Index {
 							return Optional.empty();
 						}
 					}
+
 					// else getter or un/box: OK
 				} else {
-					if (!(
-						isConstantLoad(prevOp)
-							|| prevOp == GETSTATIC
-							|| prevOp == GETFIELD
-							// primitive cast
-							|| (prevOp >= I2L && prevOp <= I2S)
-					)) {
+					if (
+							!(
+								isConstantLoad(prevOp)
+									|| prevOp == GETSTATIC
+									|| prevOp == GETFIELD
+									// primitive cast
+									|| (prevOp >= I2L && prevOp <= I2S)
+							)
+					) {
 						return Optional.empty();
 					}
 				}

--- a/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodsIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/DelegatingMethodsIndex.java
@@ -1,0 +1,148 @@
+package org.quiltmc.enigma_plugin.index;
+
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+import org.quiltmc.enigma.api.class_provider.ClassProvider;
+import org.quiltmc.enigma.api.translation.representation.MethodDescriptor;
+import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
+import org.quiltmc.enigma_plugin.Arguments;
+import org.quiltmc.enigma_plugin.util.AsmUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class DelegatingMethodsIndex extends Index {
+	private final Map<MethodEntry, List<MethodEntry>> delegatersByDelegate = new HashMap<>();
+
+	private final GetterSetterIndex getterSetterIndex;
+	// includes methods that return constants or static fields
+	private final Map<MethodNode, Boolean> getterCache = new HashMap<>();
+
+	public DelegatingMethodsIndex(GetterSetterIndex getterSetterIndex) {
+		super(Arguments.DISABLE_DELEGATING_METHODS);
+		this.getterSetterIndex = getterSetterIndex;
+	}
+
+	@Override
+	public void visitClassNode(ClassProvider classProvider, ClassNode clazz) {
+		// DEBUG TODO
+		if (clazz.name.equals("com/a/f")) {
+			final ClassEntry classEntry = new ClassEntry(clazz.name);
+			for (final MethodNode method : clazz.methods) {
+				this.getDelegate(clazz, method).ifPresent(delegate -> this.delegatersByDelegate
+						.computeIfAbsent(entryOf(classEntry, delegate), ignored -> new ArrayList<>())
+						.add(entryOf(classEntry, method))
+				);
+			}
+		}
+	}
+
+	private Optional<MethodNode> getDelegate(ClassNode clazz, MethodNode method) {
+		if (method.name.equals("<init>") || method.name.equals("<clinit>")) {
+			return Optional.empty();
+		}
+
+		final int lastOp = method.instructions.getLast().getOpcode();
+		if (lastOp < IRETURN || lastOp > RETURN) {
+			return Optional.empty();
+		}
+
+		if (!(method.instructions.getLast().getPrevious() instanceof MethodInsnNode lastCall)) {
+			return Optional.empty();
+		}
+
+		final MethodNode delegate = AsmUtil.getMethod(clazz, lastCall.name, lastCall.desc).orElse(null);
+		if (delegate == null) {
+			return Optional.empty();
+		}
+
+		final int delegaterParamCount = getParamCount(method);
+		final int delegateParamCount = getParamCount(delegate);
+		if (delegaterParamCount > delegateParamCount || (delegaterParamCount == 0 && delegateParamCount > 0)) {
+			return Optional.empty();
+		}
+
+		if (!haveDelegationCompatibleDescriptors(method, delegate)) {
+			return Optional.empty();
+		}
+
+		// DEBUG TODO
+		final List<AbstractInsnNode> instructions = new ArrayList<>();
+		method.instructions.forEach(instructions::add);
+
+		AbstractInsnNode prevInstruction = lastCall.getPrevious();
+		while (prevInstruction != null) {
+			if (prevInstruction instanceof VarInsnNode var) {
+				final int varOp = var.getOpcode();
+				if (varOp >= ILOAD && varOp <= ALOAD) {
+					if (var.var >= delegaterParamCount) {
+						// TODO
+						return Optional.empty();
+					}
+					// else loading param to pass to finalCallMethod: OK
+				} else {
+					// TODO
+					return Optional.empty();
+				}
+			} else {
+				// TODO
+				return Optional.empty();
+			}
+
+			prevInstruction = prevInstruction.getPrevious();
+		}
+		// DEBUG TODO
+		instructions.get(0);
+
+		return Optional.of(delegate);
+	}
+
+	private static MethodEntry entryOf(ClassEntry parent, MethodNode node) {
+		return new MethodEntry(parent, node.name, new MethodDescriptor(node.desc));
+	}
+
+	private static boolean haveDelegationCompatibleDescriptors(MethodNode method1, MethodNode method2) {
+		final int returnStart1 = method1.desc.lastIndexOf(')');
+		final int returnStart2 = method2.desc.lastIndexOf(')');
+
+		// same return, different params
+		return method1.desc.substring(returnStart1).equals(method2.desc.substring(returnStart2))
+				&& !method1.desc.substring(0, returnStart1).equals(method2.desc.substring(0, returnStart2));
+	}
+
+	private static String getReturnDesc(MethodNode method) {
+		return method.desc.substring(method.desc.lastIndexOf(')'));
+	}
+
+	private boolean isGetter(MethodNode method) {
+		return this.getterCache.computeIfAbsent(method, m -> {
+			// this.getterSetterIndex.getLinkedField(method) != null ||
+			return isNonInstanceGetter(m);
+		});
+	}
+
+	private static boolean isNonInstanceGetter(MethodNode method) {
+		if (method.instructions.size() == 2 && getParamCount(method) == 0) {
+			final int firstOp = method.instructions.getFirst().getOpcode();
+			if ((firstOp >= ACONST_NULL && firstOp <= LDC) || firstOp == GETSTATIC || firstOp == GETFIELD) {
+				// loading static field or constant
+				final int secondOp = method.instructions.getLast().getOpcode();
+				// returning constant
+				return secondOp >= IRETURN && secondOp <= ARETURN;
+			}
+		}
+
+		return false;
+	}
+
+	private static int getParamCount(MethodNode method) {
+		return method.parameters == null ? 0 : method.parameters.size();
+	}
+}

--- a/src/main/java/org/quiltmc/enigma_plugin/index/GetterSetterIndex.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/GetterSetterIndex.java
@@ -65,7 +65,7 @@ public class GetterSetterIndex extends Index {
 						continue; // Ignore booleans for now.
 					}
 
-					AsmUtil.getFieldFromGetter(node, method)
+					AsmUtil.getOwnedFieldFromGetter(node, method)
 							.ifPresent(field -> {
 								this.linkField(node, method, descriptor, field);
 							});

--- a/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
@@ -40,11 +40,10 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 		this.addIndex(new ConstantFieldIndex());
 		this.addIndex(new CodecIndex());
 		this.addIndex(new ConstructorParametersIndex());
-		final GetterSetterIndex getterSetterIndex = new GetterSetterIndex();
-		this.addIndex(getterSetterIndex);
+		this.addIndex(new GetterSetterIndex());
 		this.addIndex(new SimpleTypeSingleIndex());
 		this.addIndex(new DelegateParametersIndex());
-		this.addIndex(new DelegatingMethodIndex(getterSetterIndex));
+		this.addIndex(new DelegatingMethodIndex());
 		this.addIndex(new LoggerIndex());
 	}
 

--- a/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
@@ -24,7 +24,6 @@ import org.quiltmc.enigma.api.service.EnigmaServiceContext;
 import org.quiltmc.enigma.api.service.JarIndexerService;
 import org.quiltmc.enigma_plugin.QuiltEnigmaPlugin;
 import org.quiltmc.enigma_plugin.index.constant_fields.ConstantFieldIndex;
-import org.quiltmc.enigma_plugin.index.delegating_method.DelegatingMethodIndex;
 import org.quiltmc.enigma_plugin.index.simple_type_single.SimpleTypeSingleIndex;
 
 import java.util.ArrayList;

--- a/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
@@ -40,9 +40,11 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 		this.addIndex(new ConstantFieldIndex());
 		this.addIndex(new CodecIndex());
 		this.addIndex(new ConstructorParametersIndex());
-		this.addIndex(new GetterSetterIndex());
+		final GetterSetterIndex getterSetterIndex = new GetterSetterIndex();
+		this.addIndex(getterSetterIndex);
 		this.addIndex(new SimpleTypeSingleIndex());
 		this.addIndex(new DelegateParametersIndex());
+		this.addIndex(new DelegatingMethodsIndex(getterSetterIndex));
 		this.addIndex(new LoggerIndex());
 	}
 
@@ -76,10 +78,10 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 			}
 		}
 
-		for (String className : scope) {
-			ClassNode node = classProvider.get(className);
-			if (node != null) {
-				for (var index : enabledIndexes) {
+		for (var index : enabledIndexes) {
+			for (String className : scope) {
+				ClassNode node = classProvider.get(className);
+				if (node != null) {
 					index.visitClassNode(classProvider, node);
 				}
 			}

--- a/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
@@ -44,7 +44,7 @@ public class JarIndexer implements JarIndexerService, Opcodes {
 		this.addIndex(getterSetterIndex);
 		this.addIndex(new SimpleTypeSingleIndex());
 		this.addIndex(new DelegateParametersIndex());
-		this.addIndex(new DelegatingMethodsIndex(getterSetterIndex));
+		this.addIndex(new DelegatingMethodIndex(getterSetterIndex));
 		this.addIndex(new LoggerIndex());
 	}
 

--- a/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/index/JarIndexer.java
@@ -24,6 +24,7 @@ import org.quiltmc.enigma.api.service.EnigmaServiceContext;
 import org.quiltmc.enigma.api.service.JarIndexerService;
 import org.quiltmc.enigma_plugin.QuiltEnigmaPlugin;
 import org.quiltmc.enigma_plugin.index.constant_fields.ConstantFieldIndex;
+import org.quiltmc.enigma_plugin.index.delegating_method.DelegatingMethodIndex;
 import org.quiltmc.enigma_plugin.index.simple_type_single.SimpleTypeSingleIndex;
 
 import java.util.ArrayList;

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/DefaultProposalService.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/DefaultProposalService.java
@@ -39,6 +39,7 @@ public class DefaultProposalService extends NameProposerService {
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_CONSTRUCTOR_PARAMS, ConstructorParamsNameProposer::new);
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_GETTER_SETTER, GetterSetterNameProposer::new);
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_DELEGATE_PARAMS, DelegateParametersNameProposer::new);
+		this.addIfEnabled(context, indexer, Arguments.DISABLE_DELEGATING_METHODS, DelegatingMethodNameProposer::new);
 
 		// conflict fixer must be last in order to get context from other dynamic proposers
 		this.addIfEnabled(context, indexer, Arguments.DISABLE_CONFLICT_FIXER, ConflictFixProposer::new);

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegatingMethodNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegatingMethodNameProposer.java
@@ -1,0 +1,46 @@
+package org.quiltmc.enigma_plugin.proposal;
+
+import org.quiltmc.enigma.api.Enigma;
+import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
+import org.quiltmc.enigma.api.translation.representation.entry.Entry;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
+import org.quiltmc.enigma_plugin.index.DelegatingMethodIndex;
+import org.quiltmc.enigma_plugin.index.JarIndexer;
+
+import java.util.Map;
+
+public class DelegatingMethodNameProposer extends NameProposer {
+	public static final String ID = "delegating_method";
+
+	private final DelegatingMethodIndex index;
+
+	public DelegatingMethodNameProposer(JarIndexer index) {
+		super(ID);
+		this.index = index.getIndex(DelegatingMethodIndex.class);
+	}
+
+	@Override
+	public void insertProposedNames(Enigma enigma, JarIndex index, Map<Entry<?>, EntryMapping> mappings) { }
+
+	@Override
+	public void proposeDynamicNames(EntryRemapper remapper, Entry<?> obfEntry, EntryMapping oldMapping, EntryMapping newMapping, Map<Entry<?>, EntryMapping> mappings) {
+		if (obfEntry == null) {
+			this.index.forEachDelegation((delegate, delegaters) -> {
+				final EntryMapping mapping = remapper.getMapping(delegate);
+				if (mapping.targetName() != null) {
+					delegaters.forEach(delegater ->
+						this.insertDynamicProposal(mappings, delegater, new EntryMapping(mapping.targetName()))
+					);
+				}
+			});
+		} else if (obfEntry instanceof MethodEntry method) {
+			if (newMapping.targetName() != null) {
+				this.index.streamDelegaters(method).forEach(delegater ->
+					this.insertDynamicProposal(mappings, delegater, new EntryMapping(newMapping.targetName()))
+				);
+			}
+		}
+	}
+}

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegatingMethodNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegatingMethodNameProposer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.enigma_plugin.proposal;
 
 import org.quiltmc.enigma.api.Enigma;

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegatingMethodNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegatingMethodNameProposer.java
@@ -6,7 +6,7 @@ import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
-import org.quiltmc.enigma_plugin.index.DelegatingMethodIndex;
+import org.quiltmc.enigma_plugin.index.delegating_method.DelegatingMethodIndex;
 import org.quiltmc.enigma_plugin.index.JarIndexer;
 
 import java.util.Map;
@@ -31,16 +31,21 @@ public class DelegatingMethodNameProposer extends NameProposer {
 				final EntryMapping mapping = remapper.getMapping(delegate);
 				if (mapping.targetName() != null) {
 					delegaters.forEach(delegater ->
-						this.insertDynamicProposal(mappings, delegater, new EntryMapping(mapping.targetName()))
+						this.insertDelegaterName(delegater, mappings, new EntryMapping(mapping.targetName()))
 					);
 				}
 			});
 		} else if (obfEntry instanceof MethodEntry method) {
 			if (newMapping.targetName() != null) {
 				this.index.streamDelegaters(method).forEach(delegater ->
-					this.insertDynamicProposal(mappings, delegater, new EntryMapping(newMapping.targetName()))
+					this.insertDelegaterName(delegater, mappings, new EntryMapping(newMapping.targetName()))
 				);
 			}
 		}
+	}
+
+	private void insertDelegaterName(MethodEntry delegater, Map<Entry<?>, EntryMapping> mappings, EntryMapping mapping) {
+		this.insertDynamicProposal(mappings, delegater, mapping);
+		this.index.streamDelegaters(delegater).forEach(outerDelegater -> this.insertDelegaterName(outerDelegater, mappings, mapping));
 	}
 }

--- a/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegatingMethodNameProposer.java
+++ b/src/main/java/org/quiltmc/enigma_plugin/proposal/DelegatingMethodNameProposer.java
@@ -51,14 +51,14 @@ public class DelegatingMethodNameProposer extends NameProposer {
 				final EntryMapping mapping = remapper.getMapping(delegate);
 				if (mapping.targetName() != null) {
 					delegaters.forEach(delegater ->
-						this.insertDelegaterName(delegater, remapper, mappings, mapping.targetName())
+							this.insertDelegaterName(delegater, remapper, mappings, mapping.targetName())
 					);
 				}
 			});
 		} else if (obfEntry instanceof MethodEntry method) {
 			if (newMapping.targetName() != null) {
 				this.index.streamDelegaters(method).forEach(delegater ->
-					this.insertDelegaterName(delegater, remapper, mappings, newMapping.targetName())
+						this.insertDelegaterName(delegater, remapper, mappings, newMapping.targetName())
 				);
 			}
 		}
@@ -77,7 +77,7 @@ public class DelegatingMethodNameProposer extends NameProposer {
 			this.insertDynamicProposal(mappings, delegater, mapping);
 			// recur down the chain of delegaters
 			this.index.streamDelegaters(delegater).forEach(outerDelegater ->
-				this.insertDelegaterNameImpl(outerDelegater, delegateParamDescriptors, remapper, mappings, mapping)
+					this.insertDelegaterNameImpl(outerDelegater, delegateParamDescriptors, remapper, mappings, mapping)
 			);
 		}
 	}

--- a/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
@@ -40,6 +40,7 @@ import org.quiltmc.enigma_plugin.proposal.DelegatingMethodNameProposer;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public class NameProposalTest {
@@ -412,126 +413,143 @@ public class NameProposalTest {
 
 		final ValidationContext context = new ValidationContext(null);
 
-		final MethodEntry staticRoot = method(testClass, "a", obj, test, obj, i, j);
-		final String statics = "statics";
-		remapper.putMapping(context, staticRoot, new EntryMapping(statics));
-		// staticDelegating
-		assertDynamicProposal(statics, method(testClass, "a", obj, test, i, j));
-		// instanceDelegating
-		assertDynamicProposal(statics, method(testClass, "a", obj, obj, j));
+		{
+			final MethodEntry staticRoot = method(testClass, "a", obj, test, obj, i, j);
+			final String statics = "statics";
+			remapper.putMapping(context, staticRoot, new EntryMapping(statics));
+			// staticDelegating
+			assertDynamicProposal(statics, method(testClass, "a", obj, test, i, j));
+			// instanceDelegating
+			assertDynamicProposal(statics, method(testClass, "a", obj, obj, j));
+		}
 
-		final String voids = "voids";
-		final MethodEntry voidRoot = method(testClass, "a", v, obj, i, j);
-		remapper.putMapping(context, voidRoot, new EntryMapping(voids));
-		// voidDelegating
-		assertDynamicProposal(voids, method(testClass, "a", v, obj, i));
+		{
+			final String voids = "voids";
+			final MethodEntry voidRoot = method(testClass, "a", v, obj, i, j);
+			remapper.putMapping(context, voidRoot, new EntryMapping(voids));
+			// voidDelegating
+			assertDynamicProposal(voids, method(testClass, "a", v, obj, i));
+		}
 
-		final String strings = "strings";
-		final MethodEntry stringRoot = method(testClass, "b", str, obj, i, j);
-		remapper.putMapping(context, stringRoot, new EntryMapping(strings));
-		// delegatingReusedParam
-		assertDynamicProposal(strings, method(testClass, "b", str, obj, i));
-		// delegatingInlineLiteral
-		assertDynamicProposal(strings, method(testClass, "b", str, obj, j));
-		// delegatingMixed1
-		assertDynamicProposal(strings, method(testClass, "a", str, obj));
-		// delegatingMixed2
-		assertDynamicProposal(strings, method(testClass, "a", str, j));
-		// delegatingMixed3
-		assertDynamicProposal(strings, method(testClass, "a", str, i));
+		{
+			final String strings = "strings";
+			final MethodEntry stringRoot = method(testClass, "b", str, obj, i, j);
+			remapper.putMapping(context, stringRoot, new EntryMapping(strings));
+			// delegatingReusedParam
+			assertDynamicProposal(strings, method(testClass, "b", str, obj, i));
+			// delegatingInlineLiteral
+			assertDynamicProposal(strings, method(testClass, "b", str, obj, j));
+			// delegatingMixed1
+			assertDynamicProposal(strings, method(testClass, "a", str, obj));
+			// delegatingMixed2
+			assertDynamicProposal(strings, method(testClass, "a", str, j));
+			// delegatingMixed3
+			assertDynamicProposal(strings, method(testClass, "a", str, i));
+		}
 
-		final String enums = "enums";
-		final MethodEntry enumRoot = method(testClass, "c", enm, obj, i, j);
-		remapper.putMapping(context, enumRoot, new EntryMapping(enums));
-		// delegatingLocalLiteral
-		assertDynamicProposal(enums, method(testClass, "c", enm, obj, i));
-		// delegatingFinalLocalLiteral
-		assertDynamicProposal(enums, method(testClass, "c", enm, obj, j));
-		// delegatingInlineStaticField
-		assertDynamicProposal(enums, method(testClass, "a", enm, i, j));
+		{
+			final String enums = "enums";
+			final MethodEntry enumRoot = method(testClass, "c", enm, obj, i, j);
+			remapper.putMapping(context, enumRoot, new EntryMapping(enums));
+			// delegatingLocalLiteral
+			assertDynamicProposal(enums, method(testClass, "c", enm, obj, i));
+			// delegatingFinalLocalLiteral
+			assertDynamicProposal(enums, method(testClass, "c", enm, obj, j));
+			// delegatingInlineStaticField
+			assertDynamicProposal(enums, method(testClass, "a", enm, i, j));
+		}
 
-		final String ints = "ints";
-		final MethodEntry intRoot = method(testClass, "d", i, obj, i, j);
-		remapper.putMapping(context, intRoot, new EntryMapping(ints));
-		// delegatingLocalStaticField
-		assertDynamicProposal(ints, method(testClass, "b", i, i, j));
-		// delegatingInlineField
-		assertDynamicProposal(ints, method(testClass, "d", i, obj, j));
-		// delegatingLocalField
-		assertDynamicProposal(ints, method(testClass, "a", i, obj, f));
-		// delegatingInlineGetter
-		assertDynamicProposal(ints, method(testClass, "a", i, obj, b));
+		{
+			final String ints = "ints";
+			final MethodEntry intRoot = method(testClass, "d", i, obj, i, j);
+			remapper.putMapping(context, intRoot, new EntryMapping(ints));
+			// delegatingLocalStaticField
+			assertDynamicProposal(ints, method(testClass, "b", i, i, j));
+			// delegatingInlineField
+			assertDynamicProposal(ints, method(testClass, "d", i, obj, j));
+			// delegatingLocalField
+			assertDynamicProposal(ints, method(testClass, "a", i, obj, f));
+			// delegatingInlineGetter
+			assertDynamicProposal(ints, method(testClass, "a", i, obj, b));
+		}
 
-		final String chars = "chars";
-		final MethodEntry charRoot = method(testClass, "e", c, obj, i, j);
-		remapper.putMapping(context, charRoot, new EntryMapping(chars));
-		// delegatingLocalGetter
-		assertDynamicProposal(chars, method(testClass, "e", c, obj, j));
-		// delegatingInlineLiteralGetter
-		assertDynamicProposal(chars, method(testClass, "d", c, obj, i));
-		// delegatingLocalLiteralGetter
-		assertDynamicProposal(chars, method(testClass, "b", c, obj, b));
-		// delegatingInlineStaticFieldGetter
-		assertDynamicProposal(chars, method(testClass, "c", c, i, j));
-		// delegatingLocalStaticFieldGetter
-		assertDynamicProposal(chars, method(testClass, "b", c, i));
-		// delegatingUnboxing
-		assertDynamicProposal(chars, method(testClass, "b", c, j));
+		{
+			final String chars = "chars";
+			final MethodEntry charRoot = method(testClass, "e", c, obj, i, j);
+			remapper.putMapping(context, charRoot, new EntryMapping(chars));
+			// delegatingLocalGetter
+			assertDynamicProposal(chars, method(testClass, "e", c, obj, j));
+			// delegatingInlineLiteralGetter
+			assertDynamicProposal(chars, method(testClass, "d", c, obj, i));
+			// delegatingLocalLiteralGetter
+			assertDynamicProposal(chars, method(testClass, "b", c, obj, b));
+			// delegatingInlineStaticFieldGetter
+			assertDynamicProposal(chars, method(testClass, "c", c, i, j));
+			// delegatingLocalStaticFieldGetter
+			assertDynamicProposal(chars, method(testClass, "b", c, i));
+			// delegatingUnboxing
+			assertDynamicProposal(chars, method(testClass, "b", c, j));
+		}
 
-		final String floats = "floats";
-		final MethodEntry floatRoot = method(testClass, "f", f, obj, i, j);
-		remapper.putMapping(context, floatRoot, new EntryMapping(floats));
-		// delegatingArrayLoad
-		assertDynamicProposal(floats, method(testClass, "e", f, obj, i));
+		{
+			final String floats = "floats";
+			final MethodEntry floatRoot = method(testClass, "f", f, obj, i, j);
+			remapper.putMapping(context, floatRoot, new EntryMapping(floats));
+			// delegatingArrayLoad
+			assertDynamicProposal(floats, method(testClass, "e", f, obj, i));
+		}
 
-		final String chains = "chains";
-		final MethodEntry chainRoot = method(testClass, "a", b, b, c, i, j);
-		remapper.putMapping(context, chainRoot, new EntryMapping(chains));
-		// delegatingChain1
-		assertDynamicProposal(chains, method(testClass, "a", b, b, c, i));
-		// delegatingChain2
-		assertDynamicProposal(chains, method(testClass, "a", b, b, c, c));
+		{
+			final String chains = "chains";
+			final MethodEntry chainRoot = method(testClass, "a", b, b, c, i, j);
+			remapper.putMapping(context, chainRoot, new EntryMapping(chains));
+			// delegatingChain1
+			assertDynamicProposal(chains, method(testClass, "a", b, b, c, i));
+			// delegatingChain2
+			assertDynamicProposal(chains, method(testClass, "a", b, b, c, c));
+		}
+
 
 		final MethodEntry conflictWithChainAncestor = method(testClass, "b", b, b, c, i);
 		final MethodEntry childOfConflictWithChainAncestor = method(testClass, "a", b, b);
 
-		Stream
-				.of(
-					// conflictWithDelegate
-					method(testClass, "g", str, obj, i, j),
-					// conflictWithCoDelegater1
-					method(testClass, "a", str, str),
-					// conflictWithCoDelegater2
-					method(testClass, "b", str, str),
-					conflictWithChainAncestor,
-					childOfConflictWithChainAncestor,
-					// wrongReturn
-					method(testClass, "d", v, i, j),
-					// extraCall
-					method(testClass, "f", str, obj, j),
-					// nonGetterCall
-					method(testClass, "e", str, i, j),
-					// extraArithmetic
-					method(testClass, "f", str, obj, i),
-					// extraCheck
-					method(testClass, "f", str, i, j),
-					// noParamsToParams
-					method(testClass, "g", "()" + str),
-					// moreParams
-					method(testClass, "a", v, obj, i, j, str),
-					// extraSet
-					method(testClass, "b", enm, obj),
-					// extraInlineSet
-					method(testClass, "c", enm, j),
-					// extraArraySet
-					method(testClass, "g", f, obj, j)
-				)
-				.forEach(entry -> assertNotProposedBy(entry, DelegatingMethodNameProposer.ID));
+		final String id = DelegatingMethodNameProposer.ID;
 
-		// allow propagation down a delegater chain if the conflict occurred above the explicitly named delegater
-		final String chainConflict = "chainConflict";
-		remapper.putMapping(context, conflictWithChainAncestor, new EntryMapping(chainConflict));
-		assertDynamicProposal(chainConflict, childOfConflictWithChainAncestor);
+		// conflictWithDelegate
+		assertNotProposedBy(method(testClass, "g", str, obj, i, j), id);
+		// conflictWithCoDelegater1
+		assertNotProposedBy(method(testClass, "a", str, str), id);
+		// conflictWithCoDelegater2
+		assertNotProposedBy(method(testClass, "b", str, str), id);
+		assertNotProposedBy(conflictWithChainAncestor, id);
+		assertNotProposedBy(childOfConflictWithChainAncestor, id);
+		// wrongReturn
+		assertNotProposedBy(method(testClass, "d", v, i, j), id);
+		// extraCall
+		assertNotProposedBy(method(testClass, "f", str, obj, j), id);
+		// nonGetterCall
+		assertNotProposedBy(method(testClass, "e", str, i, j), id);
+		// extraArithmetic
+		assertNotProposedBy(method(testClass, "f", str, obj, i), id);
+		// extraCheck
+		assertNotProposedBy(method(testClass, "f", str, i, j), id);
+		// noParamsToParams
+		assertNotProposedBy(method(testClass, "g", "()" + str), id);
+		// moreParams
+		assertNotProposedBy(method(testClass, "a", v, obj, i, j, str), id);
+		// extraSet
+		assertNotProposedBy(method(testClass, "b", enm, obj), id);
+		// extraInlineSet
+		assertNotProposedBy(method(testClass, "c", enm, j), id);
+		// extraArraySet
+		assertNotProposedBy(method(testClass, "g", f, obj, j), id);
+
+		{
+			// allow propagation down a delegater chain if the conflict occurred above the manually named delegater
+			final String chainConflict = "chainConflict";
+			remapper.putMapping(context, conflictWithChainAncestor, new EntryMapping(chainConflict));
+			assertDynamicProposal(chainConflict, childOfConflictWithChainAncestor);
+		}
 	}
 
 	private static String methodDescOf(String returnDesc, String... paramDescriptors) {

--- a/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
@@ -433,7 +433,7 @@ public class NameProposalTest {
 		// delegatingInlineLiteral
 		assertDynamicProposal(strings, method(testClass, "b", str, obj, j));
 		// doublyDelegating
-		method(testClass, "a", str, i, j);
+		assertDynamicProposal(strings, method(testClass, "a", str, i, j));
 		// delegatingMixed1
 		method(testClass, "a", str, obj);
 		// delegatingMixed2
@@ -465,6 +465,7 @@ public class NameProposalTest {
 
 		final String chars = "chars";
 		final MethodEntry charRoot = method(testClass, "e", c, obj, i, j);
+		remapper.putMapping(context, charRoot, new EntryMapping(chars));
 		// delegatingLocalGetter
 		method(testClass, "e", c, obj, j);
 		// delegatingInlineLiteralGetter
@@ -475,6 +476,8 @@ public class NameProposalTest {
 		method(testClass, "d", c, i, j);
 		// delegatingLocalStaticFieldGetter
 		method(testClass, "b", c, i);
+		// delegatingUnboxing
+		assertDynamicProposal(chars, method(testClass, "b", c, j));
 
 		Stream
 				.of(

--- a/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
@@ -412,8 +412,8 @@ public class NameProposalTest {
 
 		final ValidationContext context = new ValidationContext(null);
 
-		final String statics = "statics";
 		final MethodEntry staticRoot = method(testClass, "a", obj, test, obj, i, j);
+		final String statics = "statics";
 		remapper.putMapping(context, staticRoot, new EntryMapping(statics));
 		// staticDelegating
 		assertDynamicProposal(statics, method(testClass, "a", obj, test, i, j));
@@ -433,12 +433,12 @@ public class NameProposalTest {
 		assertDynamicProposal(strings, method(testClass, "b", str, obj, i));
 		// delegatingInlineLiteral
 		assertDynamicProposal(strings, method(testClass, "b", str, obj, j));
-		// delegatingMixed1 TODO
-		method(testClass, "a", str, obj);
-		// delegatingMixed2 TODO
-		method(testClass, "a", str, j);
-		// delegatingMixed3 TODO
-		method(testClass, "a", str, i);
+		// delegatingMixed1
+		assertDynamicProposal(strings, method(testClass, "a", str, obj));
+		// delegatingMixed2
+		assertDynamicProposal(strings, method(testClass, "a", str, j));
+		// delegatingMixed3
+		assertDynamicProposal(strings, method(testClass, "a", str, i));
 
 		final String enums = "enums";
 		final MethodEntry enumRoot = method(testClass, "c", enm, obj, i, j);
@@ -459,22 +459,22 @@ public class NameProposalTest {
 		assertDynamicProposal(ints, method(testClass, "d", i, obj, j));
 		// delegatingLocalField
 		assertDynamicProposal(ints, method(testClass, "a", i, obj, f));
-		// delegatingInlineGetter TODO
-		method(testClass, "a", i, obj, b);
+		// delegatingInlineGetter
+		assertDynamicProposal(ints, method(testClass, "a", i, obj, b));
 
 		final String chars = "chars";
 		final MethodEntry charRoot = method(testClass, "e", c, obj, i, j);
 		remapper.putMapping(context, charRoot, new EntryMapping(chars));
-		// delegatingLocalGetter TODO
-		method(testClass, "e", c, obj, j);
-		// delegatingInlineLiteralGetter TODO
-		method(testClass, "d", c, obj, i);
-		// delegatingLocalLiteralGetter TODO
-		method(testClass, "b", c, obj, b);
-		// delegatingInlineStaticFieldGetter TODO
-		method(testClass, "c", c, i, j);
-		// delegatingLocalStaticFieldGetter TODO
-		method(testClass, "b", c, i);
+		// delegatingLocalGetter
+		assertDynamicProposal(chars, method(testClass, "e", c, obj, j));
+		// delegatingInlineLiteralGetter
+		assertDynamicProposal(chars, method(testClass, "d", c, obj, i));
+		// delegatingLocalLiteralGetter
+		assertDynamicProposal(chars, method(testClass, "b", c, obj, b));
+		// delegatingInlineStaticFieldGetter
+		assertDynamicProposal(chars, method(testClass, "c", c, i, j));
+		// delegatingLocalStaticFieldGetter
+		assertDynamicProposal(chars, method(testClass, "b", c, i));
 		// delegatingUnboxing
 		assertDynamicProposal(chars, method(testClass, "b", c, j));
 
@@ -528,12 +528,10 @@ public class NameProposalTest {
 				)
 				.forEach(entry -> assertNotProposedBy(entry, DelegatingMethodNameProposer.ID));
 
+		// allow propagation down a delegater chain if the conflict occurred above the explicitly named delegater
 		final String chainConflict = "chainConflict";
 		remapper.putMapping(context, conflictWithChainAncestor, new EntryMapping(chainConflict));
 		assertDynamicProposal(chainConflict, childOfConflictWithChainAncestor);
-		
-		/*
-		 */
 	}
 
 	private static String methodDescOf(String returnDesc, String... paramDescriptors) {

--- a/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
@@ -443,22 +443,22 @@ public class NameProposalTest {
 		final String enums = "enums";
 		final MethodEntry enumRoot = method(testClass, "c", enm, obj, i, j);
 		remapper.putMapping(context, enumRoot, new EntryMapping(enums));
-		// delegatingLocalLiteral TODO
-		method(testClass, "c", enm, obj, i);
-		// delegatingFinalLocalLiteral TODO
-		method(testClass, "c", enm, obj, j);
+		// delegatingLocalLiteral
+		assertDynamicProposal(enums, method(testClass, "c", enm, obj, i));
+		// delegatingFinalLocalLiteral
+		assertDynamicProposal(enums, method(testClass, "c", enm, obj, j));
 		// delegatingInlineStaticField
 		assertDynamicProposal(enums, method(testClass, "a", enm, i, j));
 
 		final String ints = "ints";
 		final MethodEntry intRoot = method(testClass, "d", i, obj, i, j);
 		remapper.putMapping(context, intRoot, new EntryMapping(ints));
-		// delegatingLocalStaticField TODO
-		method(testClass, "b", i, i, j);
+		// delegatingLocalStaticField
+		assertDynamicProposal(ints, method(testClass, "b", i, i, j));
 		// delegatingInlineField
 		assertDynamicProposal(ints, method(testClass, "d", i, obj, j));
-		// delegatingLocalField TODO
-		method(testClass, "a", i, obj, f);
+		// delegatingLocalField
+		assertDynamicProposal(ints, method(testClass, "a", i, obj, f));
 		// delegatingInlineGetter TODO
 		method(testClass, "a", i, obj, b);
 
@@ -478,6 +478,12 @@ public class NameProposalTest {
 		// delegatingUnboxing
 		assertDynamicProposal(chars, method(testClass, "b", c, j));
 
+		final String floats = "floats";
+		final MethodEntry floatRoot = method(testClass, "f", f, obj, i, j);
+		remapper.putMapping(context, floatRoot, new EntryMapping(floats));
+		// delegatingArrayLoad
+		assertDynamicProposal(floats, method(testClass, "e", f, obj, i));
+
 		final String chains = "chains";
 		final MethodEntry chainRoot = method(testClass, "a", b, b, c, i, j);
 		remapper.putMapping(context, chainRoot, new EntryMapping(chains));
@@ -492,33 +498,42 @@ public class NameProposalTest {
 		Stream
 				.of(
 					// conflictWithDelegate
-					method(testClass, "f", str, obj, i, j),
+					method(testClass, "g", str, obj, i, j),
 					// conflictWithCoDelegater1
 					method(testClass, "a", str, str),
 					// conflictWithCoDelegater2
 					method(testClass, "b", str, str),
+					conflictWithChainAncestor,
+					childOfConflictWithChainAncestor,
 					// wrongReturn
 					method(testClass, "d", v, i, j),
 					// extraCall
 					method(testClass, "f", str, obj, j),
 					// nonGetterCall
 					method(testClass, "e", str, i, j),
-					conflictWithChainAncestor,
-					childOfConflictWithChainAncestor,
 					// extraArithmetic
-					method(testClass, "e", str, obj, i),
+					method(testClass, "f", str, obj, i),
 					// extraCheck
 					method(testClass, "f", str, i, j),
 					// noParamsToParams
 					method(testClass, "g", "()" + str),
 					// moreParams
-					method(testClass, "a", v, obj, i, j, str)
+					method(testClass, "a", v, obj, i, j, str),
+					// extraSet
+					method(testClass, "b", enm, obj),
+					// extraInlineSet
+					method(testClass, "c", enm, j),
+					// extraArraySet
+					method(testClass, "g", f, obj, j)
 				)
 				.forEach(entry -> assertNotProposedBy(entry, DelegatingMethodNameProposer.ID));
 
 		final String chainConflict = "chainConflict";
 		remapper.putMapping(context, conflictWithChainAncestor, new EntryMapping(chainConflict));
 		assertDynamicProposal(chainConflict, childOfConflictWithChainAncestor);
+		
+		/*
+		 */
 	}
 
 	private static String methodDescOf(String returnDesc, String... paramDescriptors) {

--- a/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
+++ b/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java
@@ -34,14 +34,10 @@ import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.util.validation.ValidationContext;
-import org.quiltmc.enigma_plugin.index.DelegatingMethodIndex;
-import org.quiltmc.enigma_plugin.index.JarIndexer;
 import org.quiltmc.enigma_plugin.proposal.DelegatingMethodNameProposer;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
 
 public class NameProposalTest {
 	private static final Path JAR = Path.of("build/obf/obf.jar");
@@ -508,7 +504,6 @@ public class NameProposalTest {
 			// delegatingChain2
 			assertDynamicProposal(chains, method(testClass, "a", b, b, c, c));
 		}
-
 
 		final MethodEntry conflictWithChainAncestor = method(testClass, "b", b, b, c, i);
 		final MethodEntry childOfConflictWithChainAncestor = method(testClass, "a", b, b);

--- a/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
+++ b/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
@@ -42,134 +42,148 @@ public class ZDelegatingMethodsTest {
 		return staticRoot(this, o, 30, l);
 	}
 
-	static void staticVoidNoParamRoot() {}
-
-	static void staticVoidNoParamDelegating() {
-		staticVoidNoParamRoot();
-	}
-
-	void voidRoot(Object o, int i, long l) {}
+	void voidRoot(Object o, int i, long l) { }
 
 	void voidDelegating(Object o, int i) {
 		this.voidRoot(o, i, 0);
 	}
 
-	String root(Object o, int i, long l) {
+	String stringRoot(Object o, int i, long l) {
 		return "root";
 	}
 
-	String delegatingReuseParam(Object o, int i) {
-		return this.root(o, i, i);
+	String delegatingReusedParam(Object o, int i) {
+		return this.stringRoot(o, i, i);
 	}
 
 	String delegatingInlineLiteral(Object o, long l) {
-		return this.root(o, 2, l);
+		return this.stringRoot(o, 2, l);
 	}
 
-	String doublyDelegating(Object o, int i) {
-		return this.delegatingInlineLiteral(o, i);
-	}
-
-	String delegatingLocalLiteral(Object o, int i) {
-		long l = 3;
-		return this.root(o, i, l);
-	}
-
-	String delegatingFinalLocalLiteral(Object o, int i) {
-		final long l = 4;
-		return this.root(o, i, l);
-	}
-
-	String delegatingInlineStaticField(int i, long l) {
-		return this.root(O, i, l);
-	}
-
-	String delegatingLocalStaticField(int i, long l) {
-		Object o = O;
-		return this.root(o, i, l);
-	}
-
-	String delegatingInlineField(Object o, long l) {
-		return this.root(o, this.I, l);
-	}
-
-	String delegatingLocalField(Object o, long l) {
-		int i = this.I;
-		return this.root(o, i, l);
-	}
-
-	String delegatingInlineGetter(Object o, long l) {
-		return this.root(o, this.getI(), l);
-	}
-
-	String delegatingLocalGetter(Object o, long l) {
-		int i = this.getI();
-		return this.root(o, i, l);
-	}
-
-	String delegatingInlineLiteralGetter(Object o, int i) {
-		return this.root(o, i, this.getLiteralL1());
-	}
-
-	String delegatingLocalLiteralGetter(Object o, int i) {
-		final long l = this.getLiteralL1();
-		return this.root(o, i, l);
-	}
-
-	String delegatingInlineStaticFieldGetter(int i, long l) {
-		return this.root(this.getStaticO(), i, l);
-	}
-
-	String delegatingLocalStaticFieldGetter(int i, long l) {
-		final Object o = this.getStaticO();
-		return this.root(o, i, l);
+	String doublyDelegating(int i, long l) {
+		return this.delegatingInlineLiteral(i, l);
 	}
 
 	String delegatingMixed1(Object o) {
 		long l = this.getLiteralL1();
-		return this.root(o, this.I, l);
+		return this.stringRoot(o, this.I, l);
 	}
 
 	String delegatingMixed2(long l) {
-		return this.root(O, this.getI(), l);
+		return this.stringRoot(O, this.getI(), l);
 	}
 
 	String delegatingMixed3(int i) {
-		return this.root(this.getLiteralS(), i, this.I);
+		return this.stringRoot(this.getLiteralS(), i, this.I);
+	}
+
+	Enum<?> enumRoot(Object o, int i, long l) {
+		return null;
+	}
+
+	Enum<?> delegatingLocalLiteral(Object o, int i) {
+		long l = 3;
+		return this.enumRoot(o, i, l);
+	}
+
+	Enum<?> delegatingFinalLocalLiteral(Object o, long l) {
+		final int i = 4;
+		return this.enumRoot(o, i, l);
+	}
+
+	Enum<?> delegatingInlineStaticField(int i, long l) {
+		return this.enumRoot(O, i, l);
+	}
+
+	int intRoot(Object o, int i, long l) {
+		return 1000;
+	}
+
+	int delegatingLocalStaticField(int i, long l) {
+		Object o = O;
+		return this.intRoot(o, i, l);
+	}
+
+	int delegatingInlineField(Object o, long l) {
+		return this.intRoot(o, this.I, l);
+	}
+
+	int delegatingLocalField(Object o, float f) {
+		int i = this.I;
+		return this.intRoot(o, i, (long) f);
+	}
+
+	int delegatingInlineGetter(Object o, byte b) {
+		return this.intRoot(o, this.getI(), b);
+	}
+
+	char charRoot(Object o, int i, long l) {
+		return 'c';
+	}
+
+	char delegatingLocalGetter(Object o, long l) {
+		int i = this.getI();
+		return this.charRoot(o, i, l);
+	}
+
+	char delegatingInlineLiteralGetter(Object o, int i) {
+		return this.charRoot(o, i, this.getLiteralL1());
+	}
+
+	char delegatingLocalLiteralGetter(Object o, byte b) {
+		final long l = this.getLiteralL1();
+		return this.charRoot(o, b, l);
+	}
+
+	char delegatingInlineStaticFieldGetter(int i, long l) {
+		return this.charRoot(this.getStaticO(), i, l);
+	}
+
+	char delegatingLocalStaticFieldGetter(int i) {
+		final Object o = this.getStaticO();
+		return this.charRoot(o, i, i);
 	}
 
 	// NON-DELEGATING
 
-	String conflictingSignature(Object o, int i, long l) {
-		return this.root(o, i, l);
+	String conflictWithDelegate(Object o, int i, long l) {
+		return this.stringRoot(o, i, l);
+	}
+
+	String conflictWithCoDelegater1(String s) {
+		return this.stringRoot(s, 1, 20);
+	}
+
+	String conflictWithCoDelegater2(String s) {
+		return this.stringRoot(s, 100, -2);
 	}
 
 	void wrongReturn(int i, long l) {
-		this.root(O, i, l);
+		this.stringRoot(O, i, l);
 	}
 
 	String extraCall(Object o, long l) {
 		this.getI();
-		return this.root(o, 1, l);
+		return this.stringRoot(o, 1, l);
 	}
 
 	String nonGetterCall(int i, long l) {
-		return this.root(this.toString(), i, l);
+		return this.stringRoot(this.toString(), i, l);
 	}
 
 	String extraArithmetic(Object o, int i) {
-		return this.root(o, i, i + i);
+		return this.stringRoot(o, i, i + i);
 	}
 
 	String extraCheck(int i, long l) {
-		return this.root(O, i, i < l ? l : i);
+		return this.stringRoot(O, i, i < l ? l : i);
 	}
 
 	String noParamsToParams() {
-		return this.root(null, 0, 0);
+		return this.stringRoot(null, 0, 0);
 	}
 
-	void moreParams(int i) {
-		staticVoidNoParamRoot();
+	void moreParams(Object o, int i, long l, String s) {
+		this.stringRoot(o, i, l);
 	}
 }

--- a/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
+++ b/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
@@ -62,10 +62,6 @@ public class ZDelegatingMethodsTest {
 		return this.stringRoot(o, 2, l);
 	}
 
-	String doublyDelegating(int i, long l) {
-		return this.delegatingInlineLiteral(i, l);
-	}
-
 	String delegatingMixed1(Object o) {
 		long l = this.getLiteralL1();
 		return this.stringRoot(o, this.I, l);
@@ -150,6 +146,18 @@ public class ZDelegatingMethodsTest {
 		return this.charRoot(null, this.I_BOXED, l);
 	}
 
+	byte chainRoot(byte b, char c, int i, long l) {
+		return 2;
+	}
+
+	byte delegatingChain1(byte b, char c, int i) {
+		return this.chainRoot(b, c, i, i);
+	}
+
+	byte delegatingChain2(byte b, char c1, char c2) {
+		return this.delegatingChain1(b, c1, c2);
+	}
+
 	// NON-DELEGATING
 
 	String conflictWithDelegate(Object o, int i, long l) {
@@ -162,6 +170,14 @@ public class ZDelegatingMethodsTest {
 
 	String conflictWithCoDelegater2(String s) {
 		return this.stringRoot(s, 100, -2);
+	}
+
+	byte conflictWithChainAncestor(byte b, char c, int i) {
+		return this.delegatingChain2(b, c, (char) i);
+	}
+
+	byte childOfConflictWithChainAncestor(byte b) {
+		return this.conflictWithChainAncestor(b, (char) b, b);
 	}
 
 	void wrongReturn(int i, long l) {

--- a/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
+++ b/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
@@ -42,13 +42,13 @@ public class ZDelegatingMethodsTest {
 		return staticRoot(this, o, 30, l);
 	}
 
-	static void staticVoidNoParamRoot() { }
+	static void staticVoidNoParamRoot() {}
 
 	static void staticVoidNoParamDelegating() {
 		staticVoidNoParamRoot();
 	}
 
-	void voidRoot(Object o, int i, long l) { }
+	void voidRoot(Object o, int i, long l) {}
 
 	void voidDelegating(Object o, int i) {
 		this.voidRoot(o, i, 0);
@@ -56,6 +56,10 @@ public class ZDelegatingMethodsTest {
 
 	String root(Object o, int i, long l) {
 		return "root";
+	}
+
+	String delegatingReuseParam(Object o, int i) {
+		return this.root(o, i, i);
 	}
 
 	String delegatingInlineLiteral(Object o, long l) {
@@ -157,7 +161,7 @@ public class ZDelegatingMethodsTest {
 		return this.root(o, i, i + i);
 	}
 
-	String extraCheck(int i , long l) {
+	String extraCheck(int i, long l) {
 		return this.root(O, i, i < l ? l : i);
 	}
 

--- a/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
+++ b/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
@@ -1,0 +1,171 @@
+package com.example;
+
+public class ZDelegatingMethodsTest {
+	static Object O = new Object();
+	static byte B = 20;
+
+	int I = 0;
+
+	int getI() {
+		return this.I;
+	}
+
+	long getLiteralL1() {
+		return 1;
+	}
+
+	long getLiteralL100() {
+		return 100;
+	}
+
+	String getLiteralS() {
+		return "s";
+	}
+
+	Object getStaticO() {
+		return O;
+	}
+
+	int getStaticB() {
+		return B;
+	}
+
+	static Object staticRoot(ZDelegatingMethodsTest instance, Object o, int i, long l) {
+		return null;
+	}
+
+	static Object staticDelegating(ZDelegatingMethodsTest instance, int i, long l) {
+		return staticRoot(instance, O, i, l);
+	}
+
+	Object instanceDelegating(Object o, long l) {
+		return staticRoot(this, o, 30, l);
+	}
+
+	static void staticVoidNoParamRoot() { }
+
+	static void staticVoidNoParamDelegating() {
+		staticVoidNoParamRoot();
+	}
+
+	void voidRoot(Object o, int i, long l) { }
+
+	void voidDelegating(Object o, int i) {
+		this.voidRoot(o, i, 0);
+	}
+
+	String root(Object o, int i, long l) {
+		return "root";
+	}
+
+	String delegatingInlineLiteral(Object o, long l) {
+		return this.root(o, 2, l);
+	}
+
+	String doublyDelegating(Object o, int i) {
+		return this.delegatingInlineLiteral(o, i);
+	}
+
+	String delegatingLocalLiteral(Object o, int i) {
+		long l = 3;
+		return this.root(o, i, l);
+	}
+
+	String delegatingFinalLocalLiteral(Object o, int i) {
+		final long l = 4;
+		return this.root(o, i, l);
+	}
+
+	String delegatingInlineStaticField(int i, long l) {
+		return this.root(O, i, l);
+	}
+
+	String delegatingLocalStaticField(int i, long l) {
+		Object o = O;
+		return this.root(o, i, l);
+	}
+
+	String delegatingInlineField(Object o, long l) {
+		return this.root(o, this.I, l);
+	}
+
+	String delegatingLocalField(Object o, long l) {
+		int i = this.I;
+		return this.root(o, i, l);
+	}
+
+	String delegatingInlineGetter(Object o, long l) {
+		return this.root(o, this.getI(), l);
+	}
+
+	String delegatingLocalGetter(Object o, long l) {
+		int i = this.getI();
+		return this.root(o, i, l);
+	}
+
+	String delegatingInlineLiteralGetter(Object o, int i) {
+		return this.root(o, i, this.getLiteralL1());
+	}
+
+	String delegatingLocalLiteralGetter(Object o, int i) {
+		final long l = this.getLiteralL1();
+		return this.root(o, i, l);
+	}
+
+	String delegatingInlineStaticFieldGetter(int i, long l) {
+		return this.root(this.getStaticO(), i, l);
+	}
+
+	String delegatingLocalStaticFieldGetter(int i, long l) {
+		final Object o = this.getStaticO();
+		return this.root(o, i, l);
+	}
+
+	String delegatingMixed1(Object o) {
+		long l = this.getLiteralL1();
+		return this.root(o, this.I, l);
+	}
+
+	String delegatingMixed2(long l) {
+		return this.root(O, this.getI(), l);
+	}
+
+	String delegatingMixed3(int i) {
+		return this.root(this.getLiteralS(), i, this.I);
+	}
+
+	// NON-DELEGATING
+
+	String conflictingSignature(Object o, int i, long l) {
+		return this.root(o, i, l);
+	}
+
+	void wrongReturn(int i, long l) {
+		this.root(O, i, l);
+	}
+
+	String extraCall(Object o, long l) {
+		this.getI();
+		return this.root(o, 1, l);
+	}
+
+	String nonGetterCall(int i, long l) {
+		return this.root(this.toString(), i, l);
+	}
+
+	String extraArithmetic(Object o, int i) {
+		return this.root(o, i, i + i);
+	}
+
+	String extraCheck(int i , long l) {
+		return this.root(O, i, i < l ? l : i);
+	}
+
+	String noParamsToParams() {
+		return this.root(null, 0, 0);
+	}
+
+	void moreParams(int i) {
+		staticVoidNoParamRoot();
+	}
+}

--- a/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
+++ b/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
@@ -6,6 +6,8 @@ public class ZDelegatingMethodsTest {
 
 	int I = 0;
 
+	Integer I_BOXED = 100;
+
 	int getI() {
 		return this.I;
 	}
@@ -142,6 +144,10 @@ public class ZDelegatingMethodsTest {
 	char delegatingLocalStaticFieldGetter(int i) {
 		final Object o = this.getStaticO();
 		return this.charRoot(o, i, i);
+	}
+
+	char delegatingUnboxing(long l) {
+		return this.charRoot(null, this.I_BOXED, l);
 	}
 
 	// NON-DELEGATING

--- a/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
+++ b/src/testInputs/java/com/example/ZDelegatingMethodsTest.java
@@ -5,6 +5,7 @@ public class ZDelegatingMethodsTest {
 	static byte B = 20;
 
 	int I = 0;
+	long[] LONGS = new long[0];
 
 	Integer I_BOXED = 100;
 
@@ -146,6 +147,14 @@ public class ZDelegatingMethodsTest {
 		return this.charRoot(null, this.I_BOXED, l);
 	}
 
+	float floatRoot(Object o, int i, long l) {
+		return 0.1f;
+	}
+
+	float delegatingArrayLoad(Object o, int i) {
+		return this.floatRoot(o, i, this.LONGS[i]);
+	}
+
 	byte chainRoot(byte b, char c, int i, long l) {
 		return 2;
 	}
@@ -207,5 +216,19 @@ public class ZDelegatingMethodsTest {
 
 	void moreParams(Object o, int i, long l, String s) {
 		this.stringRoot(o, i, l);
+	}
+
+	Enum<?> extraSet(Object o) {
+		this.I = 2;
+		return this.enumRoot(o, 0, 0);
+	}
+
+	Enum<?> extraInlineSet(long l) {
+		return this.enumRoot(l, this.I = 2, l);
+	}
+
+	float extraArraySet(Object o, long l) {
+		this.LONGS[0] = l;
+		return this.floatRoot(o, 0, l);
 	}
 }


### PR DESCRIPTION
Adds a proposer that finds methods that delegate to other methods in the same class and names the delegaters after their delegates.

See the [test input](<https://github.com/supersaiyansubtlety/quilt-enigma-plugin/blob/delegating-methods/src/testInputs/java/com/example/ZDelegatingMethodsTest.java>) and the [test](<https://github.com/supersaiyansubtlety/quilt-enigma-plugin/blob/delegating-methods/src/test/java/org/quiltmc/enigma_plugin/NameProposalTest.java#L395>) for what delegaters may/not contain.